### PR TITLE
Fix removal of models from collections to be based on the model itself a...

### DIFF
--- a/lib/reactions/collection.js
+++ b/lib/reactions/collection.js
@@ -46,9 +46,14 @@ var CollectionReaction = Reaction.extend({
     }
   },
 
-  remove: function(index) {
-    this.el.children().eq(index).remove()
-    this.templates.splice(index, 1)
+  remove: function(index, model) {
+    var templateToRemove = _(this.templates).find(function(template) {
+      return template.template.data('model') === model;
+    })
+    //if (templateToRemove) {
+      templateToRemove.template.remove()
+      this.templates.splice(_(this.templates).indexOf(templateToRemove), 1);
+    //}
   },
   
   init: function(next) {
@@ -76,7 +81,7 @@ var CollectionReaction = Reaction.extend({
       if(this.polymorphicKey) {
         this.collectionPresenter.on("change:" + this.polymorphicKey, function(model) {
           var index = this.collectionPresenter.indexOf(model)
-          this.remove(index)
+          this.remove(index, model)
           this.add(model, index)
         }, this)
       }
@@ -90,7 +95,7 @@ var CollectionReaction = Reaction.extend({
       }, this)
 
       this.collectionPresenter.on("remove", function(model, collection, opts) {
-        this.remove(opts.index)
+        this.remove(opts.index, model)
       }, this) 
     }
   }

--- a/test/collection.js
+++ b/test/collection.js
@@ -1,0 +1,49 @@
+var path = require("path")
+  , expect = require("expect.js")
+  , fs = require("fs")
+  , Backbone = require("backbone")
+  , generateTemplate = require("./util").generateTemplate
+
+describe("A collection template", function() {
+
+
+  describe("when I bind to the collection", function() {
+    beforeEach(function () {
+      this.things = new Backbone.Collection([ new Backbone.Model({ type: "awesome" }), new Backbone.Model({ type: "cool" }) ])
+      this.markup = fs.readFileSync(__dirname + "/support/polymorphic.html").toString()
+      this.template = generateTemplate({ things: this.things }, this.markup)
+    })
+ 
+    it("should change the item when the type changes", function() {
+      expect($(".things- .thing-:nth-child(1)").html()).to.be("awesome")
+      expect($(".things- .thing-:nth-child(2)").html()).to.be("cool")
+
+      expect($(".things- .thing-:nth-child(1)").hasClass("whenAwesome-")).to.be(true)
+      expect($(".things- .thing-:nth-child(2)").hasClass("whenCool-")).to.be(true)
+
+      this.things.at(0).set("type", "cool")
+      this.things.at(1).set("type", "awesome")
+
+      expect($(".things- .thing-:nth-child(1)").html()).to.be("cool")
+      expect($(".things- .thing-:nth-child(2)").html()).to.be("awesome")
+
+      expect($(".things- .thing-:nth-child(1)").hasClass("whenCool-")).to.be(true)
+      expect($(".things- .thing-:nth-child(2)").hasClass("whenAwesome-")).to.be(true)
+    })
+
+    it("should remove the correct element on remove even if the element has moved", function() {
+      var model = this.things.last()
+      expect($(".things- .thing-:nth-child(2)").html()).to.be("cool")
+      var el = $(".things- .thing-:nth-child(2)")
+      // move cool from second position to the first position (outside of endDash)
+      el.insertBefore($('.things- .thing-:nth-child(1)'))
+      //we expect the first one to be cool now
+      expect($('.things- .thing-:nth-child(1)').html()).to.be('cool')
+      // then we remove cool
+      this.things.remove(model)
+      // and expect the first one to be awesome
+      expect($(".things- .thing-:nth-child(1)").html()).to.be("awesome")
+    })
+
+  }) 
+})


### PR DESCRIPTION
...nd not its index in the dom as thid parties (such as jquery UI) can move elements around in the dom and enddash doesn't know where they are
@tobowers 
