### PR TITLE
Add a debugger directive to end-dash.

### DIFF
--- a/lib/end-dash.js
+++ b/lib/end-dash.js
@@ -7,6 +7,7 @@ var Parser = require("./parser")
   , PartialReaction = require("./reactions/partial")
   , ViewReaction = require("./reactions/view")
   , ScopeReaction = require("./reactions/scope")
+  , DebuggerReaction = require('./reactions/debugger')
 
 module.exports = Parser
 
@@ -18,5 +19,6 @@ Parser.registerReaction(AttributeReaction)
 Parser.registerReaction(VariableReaction)
 Parser.registerReaction(ConditionalReaction)
 Parser.registerReaction(ViewReaction)
+Parser.registerReaction(DebuggerReaction)
 
 require('./compile')

--- a/lib/reactions/debugger.js
+++ b/lib/reactions/debugger.js
@@ -1,0 +1,38 @@
+// Open up a debugger in development mode to inspect the context of the
+// template.
+//
+// Open a context in the highest template scope:
+//
+// <body>
+//   <div debugger />
+// </body>
+//
+// In a child model scope:
+//
+// <body>
+//   <div data-scope="questions-">
+//     <!-- Open a debugger in the scope of get('questions') -->
+//     <div debugger />
+//   </div>
+// </body>
+var Reaction = require('../reaction');
+
+var DebuggerReaction = Reaction.extend({
+  init: function() {
+    this.model.on('sync', this.startDebugger.bind(this));
+  },
+
+  startDebugger: function() {
+    var customDebugger = this.constructor.customDebugger;
+
+    if (customDebugger) {
+      customDebugger.apply(this);
+    } else {
+      debugger;
+    }
+  }
+}, {
+  selector: '[debugger]'
+});
+
+module.exports = DebuggerReaction;

--- a/test/debugger.js
+++ b/test/debugger.js
@@ -1,0 +1,56 @@
+var generateTemplate = require('./util').generateTemplate,
+    DebuggerReaction = require('../lib/reactions/debugger'),
+    Backbone = require('backbone'),
+    Model = Backbone.Model,
+    expect = require('expect.js');
+
+describe('<div debugger>', function() {
+  beforeEach(function() {
+    var dog = new Model({name: 'Fido'});
+
+    this.model = new Model({
+      name: 'Mukund',
+      dog: dog
+    });
+  });
+
+  describe('in the topmost scope', function() {
+    beforeEach(function() {
+      var src = '<div debugger></div>';
+      this.template = generateTemplate(this.model, src);
+    });
+
+    it('calls the debugger when the model is synced', function(done) {
+      DebuggerReaction.customDebugger = done;
+      this.model.trigger('sync');
+    });
+
+    it('passes the template context', function(done) {
+      DebuggerReaction.customDebugger = function() {
+        expect(this.model.get('name')).to.be('Mukund');
+        done();
+      };
+
+      this.model.trigger('sync');
+    });
+  });
+
+  describe('nested in a scope', function() {
+    beforeEach(function() {
+      var src = '<div class="dog-">'+
+                '  <div debugger></div>'+
+                '</div>';
+
+      this.template = generateTemplate(this.model, src);
+    });
+
+    it('passes the nested context', function(done) {
+      DebuggerReaction.customDebugger = function() {
+        expect(this.model.get('name')).to.be('Fido');
+        done();
+      };
+
+      this.model.get('dog').trigger('sync');
+    });
+  });
+});


### PR DESCRIPTION
Adding @tobowers as reviewer, cc @devmanhinton

We want to be able to run things in the context of the presenter once the data has loaded.

When do we start the debugger? I initially had it do a `setTimeout`, but that's kind of ugly and arbitrary. Now, I'm doing it when the model's loaded but it's possible that the presenter doesn't have a model. Maybe a `setTimeout` is fine given that we're in dev mode anyway...
