### PR TITLE
Move templateRegistry/templateClassRegistry into new class, TemplateStore

### DIFF
--- a/lib/compile.js
+++ b/lib/compile.js
@@ -1,11 +1,9 @@
-var EndDash = require("./end-dash")
-  , fs = require("fs")
+// We're just keeping this around because base-backbone expects it to be here.
+// In the long run, we should probably not expose lib/compile.
+var TemplateStore = require('./template_store'),
+    EndDash = require('./end-dash'),
+    _ = require('underscore');
 
-var compile = module.exports = function(module, filename) {
-  var content = fs.readFileSync(filename, 'utf8')
-  var Parsed = new EndDash(content, { templateName: filename.replace(/\.js\.ed(\.erb)?$/, "") })
-  module.exports = Parsed.generate()
-}
-if(require.extensions) {
-   require.extensions[".ed"] = require.extensions[".js.ed"] = compile
-}
+var Compiler = EndDash.compile;
+Compiler.registerTemplate = TemplateStore.load;
+module.exports = Compiler;

--- a/lib/end-dash.js
+++ b/lib/end-dash.js
@@ -1,24 +1,39 @@
-var Parser = require("./parser")
-  , AttributeReaction = require("./reactions/attribute")
-  , CollectionReaction = require("./reactions/collection")
-  , ModelReaction = require("./reactions/model")
-  , VariableReaction = require("./reactions/variable")
-  , ConditionalReaction = require("./reactions/conditional")
-  , PartialReaction = require("./reactions/partial")
-  , ViewReaction = require("./reactions/view")
-  , ScopeReaction = require("./reactions/scope")
-  , DebuggerReaction = require('./reactions/debugger')
+var _ = require('underscore'),
+    Parser = require('./parser'),
+    TemplateStore = require('./template_store'),
+    AttributeReaction = require('./reactions/attribute'),
+    CollectionReaction = require('./reactions/collection'),
+    ModelReaction = require('./reactions/model'),
+    VariableReaction = require('./reactions/variable'),
+    ConditionalReaction = require('./reactions/conditional'),
+    PartialReaction = require('./reactions/partial'),
+    ViewReaction = require('./reactions/view'),
+    ScopeReaction = require('./reactions/scope'),
+    DebuggerReaction = require('./reactions/debugger');
 
-module.exports = Parser
+// These two methods are exported simply because base-backbone expects them.
+// We should probably rework this interface at some point.
+exports.compile = function(module, filename) {
+  var fs = require('fs'),
+      markup = fs.readFileSync(filename, 'utf8'),
+      templateName = filename.replace(/\.js\.ed(\.erb)?$/, '');
 
-Parser.registerReaction(PartialReaction)
-Parser.registerReaction(ScopeReaction)
-Parser.registerReaction(CollectionReaction)
-Parser.registerReaction(ModelReaction)
-Parser.registerReaction(AttributeReaction)
-Parser.registerReaction(VariableReaction)
-Parser.registerReaction(ConditionalReaction)
-Parser.registerReaction(ViewReaction)
-Parser.registerReaction(DebuggerReaction)
+  module.exports = TemplateStore.loadAndParse(templateName, markup);
+};
 
-require('./compile')
+exports.registerTemplate = TemplateStore.load;
+
+Parser.registerReaction(PartialReaction);
+Parser.registerReaction(ScopeReaction);
+Parser.registerReaction(CollectionReaction);
+Parser.registerReaction(ModelReaction);
+Parser.registerReaction(AttributeReaction);
+Parser.registerReaction(VariableReaction);
+Parser.registerReaction(ConditionalReaction);
+Parser.registerReaction(ViewReaction);
+Parser.registerReaction(DebuggerReaction);
+
+// Necessary to magically override the require extensions.
+if (require.extensions && !require.extensions['.ed']) {
+  require.extensions['.ed'] = require.extensions['.js.ed'] = exports.compile;
+}

--- a/lib/parser.js
+++ b/lib/parser.js
@@ -1,11 +1,9 @@
 var Backbone = require("backbone")
   , Template = require("./template")
+  , path = require('path')
   , util = require("./util")
-  , path = require("path")
   , _ = require("underscore")
-  , reactions = []
-  , templateClassRegistry = {}
-  , templateRegistry = {}
+  , reactions = [];
 
 var Parser = module.exports = function(markup, opts) {
   opts = opts || {}
@@ -17,12 +15,13 @@ var Parser = module.exports = function(markup, opts) {
   this.structureStack = [this.structure]
 
   this._state = {
-    templates: templateRegistry,
+    templates: opts.templates,
     pathStack: [this.absolutePath],
     currentDir: function() {
       return path.dirname(_.last(this.pathStack))
     }
   }
+
   this.preparse(this.markup)
   this.parse(this.markup)
 }
@@ -31,26 +30,6 @@ _.extend(Parser.prototype, Backbone.Events)
 
 Parser.registerReaction = function(reaction) {
   reactions.push(reaction)
-}
-
-Parser.registerTemplate = function(name, View) {
-  name = path.normalize(name)
-  templateRegistry[name] = View
-}
-
-Parser.getTemplate = function(name) {
-  var rawHtml
-  name = path.normalize(name)
-
-  if(templateClassRegistry[name]) {
-    return templateClassRegistry[name]
-  } else {
-    rawHtml = templateRegistry[name]
-    if(!rawHtml) {
-      throw new Error("Could not find template: " + name)
-    }
-    return templateClassRegistry[name] = (new Parser(rawHtml, { templateName: name })).generate()
-  }
 }
 
 Parser.prototype.traverse = function(el, callback) {

--- a/lib/reactions/collection.js
+++ b/lib/reactions/collection.js
@@ -1,4 +1,5 @@
 var Parser = require("../parser")
+  , TemplateStore = require('../template_store')
   , Reaction = require("../reaction")
   , inflection = require("inflection")
   , _ = require("underscore")
@@ -18,7 +19,7 @@ var CollectionReaction = Reaction.extend({
   },
 
   getTemplate: function(model) {
-    if(this.polymorphicKey) {
+    if (this.polymorphicKey) {
       var value = get(model, this.polymorphicKey)
       return this.itemTemplates[value]
     } else {
@@ -55,7 +56,7 @@ var CollectionReaction = Reaction.extend({
       this.templates.splice(_(this.templates).indexOf(templateToRemove), 1);
     //}
   },
-  
+
   init: function(next) {
     this.collection = this.get(this.collectionName) || []
     this.collectionPresenter = this.getPresenter(this.collection)
@@ -105,18 +106,20 @@ var CollectionReaction = Reaction.extend({
   reactIf: function(el) {
     return rules.collection(el)
   },
- 
+
   parse: function(el, state) {
     var collectionName = rules.collection(el)
       , polymorphicKey = rules.polymorphicKey(el)
       , templates = {}
-      , children = el.children()
+      , children = el.children();
 
     children.each(function(i, element) {
       var child = $(element)
         , whenValue = rules.polymorphicValue(child)
-        , template = (new Parser(child, { templateName: _.last(state.pathStack) }))
-      templates[whenValue] = template.generate()
+        , templatePath = _.last(state.pathStack)
+        , Template = TemplateStore.loadAndParse(templatePath+whenValue, child);
+
+      templates[whenValue] = Template;
       child.remove()
     })
 
@@ -128,6 +131,5 @@ var CollectionReaction = Reaction.extend({
       polymorphicKey: polymorphicKey
     }
   }
-  
 })
 module.exports = CollectionReaction

--- a/lib/template_store.js
+++ b/lib/template_store.js
@@ -1,0 +1,68 @@
+// This class is responsible for storing raw HTML templates when they're loaded
+// and then returning template objects (lazily).
+var _ = require('underscore'),
+    path = require('path'),
+    Parser = require('./parser'),
+    TemplateStore = {},
+    RAW_TEMPLATES = {},
+    TEMPLATES = {};
+
+var pathToName = function(templatePath) {
+  return path.normalize(templatePath);
+};
+
+var _parseTemplate = function(templatePath) {
+  var name = pathToName(templatePath);
+
+  if (!TemplateStore.isLoaded(name)) {
+    throw new Error('Could not find template: '+name);
+  }
+
+  var markup = RAW_TEMPLATES[name];
+
+  return (new Parser(markup, {
+    templateName: name,
+    templates: RAW_TEMPLATES
+  })).generate();
+};
+
+TemplateStore.isLoaded = function(templatePath) {
+  return !!RAW_TEMPLATES[templatePath];
+};
+
+TemplateStore.isParsed = function(templatePath) {
+  return !!TEMPLATES[templatePath];
+};
+
+TemplateStore.load = function(templatePath, markup) {
+  var name = pathToName(templatePath);
+
+  RAW_TEMPLATES[name] = markup;
+
+  if (this.isParsed(name)) {
+    delete TEMPLATES[name];
+  }
+};
+
+TemplateStore.loadAndParse = function(templatePath, markup) {
+  this.load(templatePath, markup);
+  return this.getTemplate(templatePath);
+};
+
+TemplateStore.getTemplate = function(templatePath) {
+  var name = pathToName(templatePath);
+
+  if (!this.isParsed(name)) {
+    TEMPLATES[name] = _parseTemplate(name);
+  }
+
+  return TEMPLATES[name];
+};
+
+_.bindAll(TemplateStore, 'isLoaded',
+                         'isParsed',
+                         'load',
+                         'loadAndParse',
+                         'getTemplate');
+
+module.exports = TemplateStore;

--- a/test/backbone_integration.js
+++ b/test/backbone_integration.js
@@ -26,8 +26,6 @@ describe("when integrating with backbone", function() {
         , markup = '<div><div class = "name-"></div><div class = "title-"></div></div>'
         , template = generateTemplate(model, markup)
 
-      $("body").html(template.template)
-
       expect($(".name-").html()).to.be("q1")
       expect($(".title-").html()).to.be("herp")
     })

--- a/test/collection.js
+++ b/test/collection.js
@@ -5,11 +5,13 @@ var path = require("path")
   , generateTemplate = require("./util").generateTemplate
 
 describe("A collection template", function() {
-
-
   describe("when I bind to the collection", function() {
     beforeEach(function () {
-      this.things = new Backbone.Collection([ new Backbone.Model({ type: "awesome" }), new Backbone.Model({ type: "cool" }) ])
+      this.things = new Backbone.Collection([
+        new Backbone.Model({ type: "awesome" }),
+        new Backbone.Model({ type: "cool" })
+      ]);
+
       this.markup = fs.readFileSync(__dirname + "/support/polymorphic.html").toString()
       this.template = generateTemplate({ things: this.things }, this.markup)
     })

--- a/test/helper.js
+++ b/test/helper.js
@@ -1,6 +1,7 @@
 var jsdom = require("jsdom")
 
 before(function(done) {
+  require('../lib/end-dash');
   jsdom.env({
     html: "<html><head></head><body></body></html>",
     scripts: [__dirname + "/../vendor/jquery.js"],

--- a/test/partials.js
+++ b/test/partials.js
@@ -5,6 +5,7 @@ var path = require("path")
   , _ = require("underscore")
   , jqts = require("../lib/util").jqts
   , EndDash = require("../lib/end-dash")
+  , TemplateStore = require('../lib/template_store')
   , generateTemplate = require("./util").generateTemplate
 
 describe("A template with partials", function() {
@@ -21,10 +22,10 @@ describe("A template with partials", function() {
     }
 
     _(templates).each(function(template) {
-      EndDash.registerTemplate(template, fs.readFileSync(__dirname + template).toString())
+      TemplateStore.load(template, fs.readFileSync(__dirname + template).toString())
     })
 
-    var template = generateTemplate(model, "/support/partials.html")
+    var template = generateTemplate(model, '/support/partials.html')
 
     expect($(".items- .item-:nth-child(1) .variable-").html()).to.be("wat1")
     expect($(".items- .item-:nth-child(2) .variable-").html()).to.be("wat2")

--- a/test/template_store.js
+++ b/test/template_store.js
@@ -1,0 +1,80 @@
+var expect = require("expect.js"),
+    Parser = require('../lib/parser'),
+    Template = require('../lib/template'),
+    TemplateStore = require('../lib/template_store'),
+
+    // easier to read..
+    isLoaded = TemplateStore.isLoaded,
+    isParsed = TemplateStore.isParsed,
+    load = TemplateStore.load,
+    loadAndParse = TemplateStore.loadAndParse,
+    getTemplate = TemplateStore.getTemplate;
+
+describe('TemplateStore', function() {
+  describe('.load', function() {
+    it('loads markup without parsing', function() {
+      load('user', '<div id="user"></div>');
+      expect(isLoaded('user')).to.be(true);
+      expect(isParsed('user')).to.be(false);
+    });
+  });
+
+  describe('.getTemplate', function() {
+    it('retrieves loaded templates', function() {
+      load('user', '<div id="user"></div>');
+      var UserTemplate = getTemplate('user');
+      expect(UserTemplate).to.be.a(Template.constructor);
+    });
+
+    it('returns the same Template object when called repeatedly', function() {
+      load('user', '<div id="user"></div>');
+      var UserTemplate = getTemplate('user'),
+          UserTemplate2 = getTemplate('user');
+
+      expect(UserTemplate2).to.equal(UserTemplate);
+    });
+
+    it('retrieves templates using a normalized path', function() {
+      var BarTemplate = loadAndParse('/foo/bar', '<div id="bar"></div>');
+
+      expect(getTemplate('/foo/bar')).to.equal(BarTemplate);
+      expect(getTemplate('/foo/bar/baz/..')).to.equal(BarTemplate);
+      expect(getTemplate('/foo/baz/../bar')).to.equal(BarTemplate);
+    });
+
+    it('errors when it can\'t find a template', function() {
+      expect(function() {
+        getTemplate('notLoaded')
+      }).to.throwError(/Could not find template/);
+    });
+
+    it('parses templates that haven\'t been parsed', function() {
+      load('user', '<div id="user"></div>');
+
+      expect(isParsed('user')).to.be(false);
+      getTemplate('user');
+      expect(isParsed('user')).to.be(true);
+    });
+  });
+
+  describe('.loadAndParse', function() {
+    it('loads and parses', function() {
+      loadAndParse('user', '<div id="user"></div>');
+
+      expect(isLoaded('user')).to.be(true);
+      expect(isParsed('user')).to.be(true);
+    });
+
+    it('returns a Template object', function() {
+      var UserTemplate = loadAndParse('user', '<div id="user"></div>');
+      expect(UserTemplate).to.be.a(Template.constructor);
+    });
+
+    it('overwrites loaded templates', function() {
+      var UserTemplate = loadAndParse('user', '<div id="user"></div>'),
+          UserTemplate2 = loadAndParse('user', '<div id="user"></div>');
+
+      expect(UserTemplate2).to.not.equal(UserTemplate);
+    });
+  });
+});

--- a/test/util.js
+++ b/test/util.js
@@ -1,14 +1,30 @@
-function generateTemplate(model, markup) {
-  var EndDash = require("../lib/end-dash")
-    , Template, template
-  if(markup.charAt(0) === '/') {
-    Template = new EndDash.getTemplate(markup)
-  } else {
-    Template = new EndDash(markup).generate()
-  }
-  template = new Template(model, { templateName: "/test/support/template.html" })
+var TemplateStore = require('../lib/template_store'),
+    testTemplateCount = 0;
 
-  $("body").html(template.template)
-  return template
+exports.generateTemplate = function(model, markupOrPath) {
+  var Template, templatePath;
+
+  if (markupOrPath.charAt(0) === '/') {
+    templatePath = markupOrPath;
+    Template = TemplateStore.getTemplate(templatePath);
+
+  } else {
+    templatePath = generateTestTemplatePath();
+    Template = TemplateStore.loadAndParse(templatePath, markupOrPath);
+  }
+
+  var template = new Template(model, {
+    templateName: templatePath+'.html'
+  });
+
+  $('body').html(template.template);
+  return template;
 }
-module.exports = { generateTemplate: generateTemplate }
+
+// We need to generate random, unique names for templates so we don't
+// accidentally overwrite stuff.
+var generateTestTemplatePath = function() {
+  var templatePath = '/test/support/template'+testTemplateCount;
+  testTemplateCount++;
+  return templatePath;
+};


### PR DESCRIPTION
@tobowers, please review this sometime today or pass it on to someone else (bglusman?) if you're busy with higher priority stuff. (cc @devmanhinton) It's a decent sized branch, so I want to know of any red flags with how it's designed so I have time to fix it.

This branch decouples the `templateRegistry` and `templateClassRegistry` into its own class, `TemplateStore`. It should preserve current behavior.
1. Tests pass
2. I've QA'ed a bit, but this should be tested thoroughly on staging.
3. **TODO** I also need to add tests for the TemplateStore class.
4. **TODO** Add documentation. For example, `TemplateStore.load` should not actually parse the markup until we try to retrieve it. This isn't documented very well yet.

Once I do 2. and 3., we can merge this branch.
