### PR TITLE
Better grunt specs

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -10,22 +10,15 @@ module.exports = function(grunt) {
         reporter: 'spec'
       },
 
-      all: {src: ['test/**/*.js']}
+      all: {src: ['test/**/*.js', '!test/support/**/*.js']}
     },
 
     watch: {
       all: {
         files: ['test/**/*.js'],
-        tasks: ['simplemocha'],
-        options: {spawn: false}
+        tasks: ['simplemocha']
       }
     }
-  });
-
-  // Only run tests for the changed files. See:
-  // https://github.com/gruntjs/grunt-contrib-watch#compiling-files-as-needed
-  grunt.event.on('watch', function(action, filepath) {
-    grunt.config('simplemocha.all.src', filepath);
   });
 
   grunt.registerTask('default', ['simplemocha']);

--- a/docs/attribute_interpolation.markdown
+++ b/docs/attribute_interpolation.markdown
@@ -1,6 +1,6 @@
 [](root)
 ```coffeescript
-require("../test/helper")
+require("../test/support/helper")
 Model = require("backbone").Model
 EndDash = require("../lib/end-dash").generateTemplate
 ```

--- a/docs/scopes.markdown
+++ b/docs/scopes.markdown
@@ -1,6 +1,6 @@
 [](root)
 ```coffeescript
-require("../test/helper")
+require("../test/support/helper")
 Model = require("Backbone").Model
 EndDash = require("../lib/end-dash").generateTemplate
 ```

--- a/docs/variables.markdown
+++ b/docs/variables.markdown
@@ -4,11 +4,11 @@
 
 [](root)
 ```coffeescript
-require("../test/helper")
+require("../test/support/helper")
 Model = require("Backbone").Model
 EndDash = require("../lib/end-dash").generateTemplate
 ```
-The above code just imports test/helper and the backbone default model.
+The above code just imports test/support/helper and the backbone default model.
 
 [](beforeEach)
 ```coffeescript

--- a/test/attributes.js
+++ b/test/attributes.js
@@ -1,8 +1,10 @@
+require('./support/helper');
+
 var path = require("path")
   , Model = require("backbone").Model
   , expect = require("expect.js")
   , fs = require("fs")
-  , generateTemplate = require("./util").generateTemplate
+  , generateTemplate = require("./support/generate_template")
 
 describe("An element with an attribute", function() {
   beforeEach(function() {

--- a/test/backbone_integration.js
+++ b/test/backbone_integration.js
@@ -1,7 +1,9 @@
+require('./support/helper');
+
 var expect = require("expect.js")
   , fs = require("fs")
   , Backbone = require("backbone")
-  , generateTemplate = require("./util").generateTemplate
+  , generateTemplate = require("./support/generate_template")
   , Factory = require("test-things").Factory
 
 describe("when integrating with backbone", function() {

--- a/test/bind.js
+++ b/test/bind.js
@@ -1,10 +1,12 @@
+require('./support/helper');
+
 var path = require("path")
   , expect = require("expect.js")
   , fs = require("fs")
   , Backbone = require("backbone")
   , Model = Backbone.Model
   , Collection = Backbone.Collection
-  , generateTemplate = require("./util").generateTemplate
+  , generateTemplate = require("./support/generate_template")
 
 describe("When I initialize a template with a model", function() {
 

--- a/test/collection.js
+++ b/test/collection.js
@@ -1,8 +1,10 @@
+require('./support/helper');
+
 var path = require("path")
   , expect = require("expect.js")
   , fs = require("fs")
   , Backbone = require("backbone")
-  , generateTemplate = require("./util").generateTemplate
+  , generateTemplate = require("./support/generate_template")
 
 describe("A collection template", function() {
   describe("when I bind to the collection", function() {

--- a/test/conditional_attributes.js
+++ b/test/conditional_attributes.js
@@ -1,10 +1,10 @@
+require('./support/helper');
+
 var path = require("path")
   , expect = require("expect.js")
   , fs = require("fs")
   , Backbone = require("backbone")
-  , generateTemplate = require("./util").generateTemplate
-
-require("./helper")
+  , generateTemplate = require("./support/generate_template")
 
 describe("A conditional attribute", function() {
 

--- a/test/conditional_tag.js
+++ b/test/conditional_tag.js
@@ -1,9 +1,10 @@
+require('./support/helper');
+
 var path = require("path")
   , expect = require("expect.js")
   , fs = require("fs")
-  , helper = require("./helper")
   , Backbone = require("backbone")
-  , generateTemplate = require("./util").generateTemplate
+  , generateTemplate = require("./support/generate_template")
 
 describe("A conditional tag", function() {
   beforeEach(function() {

--- a/test/debugger.js
+++ b/test/debugger.js
@@ -1,4 +1,6 @@
-var generateTemplate = require('./util').generateTemplate,
+require('./support/helper');
+
+var generateTemplate = require('./support/generate_template')
     DebuggerReaction = require('../lib/reactions/debugger'),
     Backbone = require('backbone'),
     Model = Backbone.Model,

--- a/test/embedded_models.js
+++ b/test/embedded_models.js
@@ -1,7 +1,9 @@
+require('./support/helper');
+
 var path = require("path")
   , expect = require("expect.js")
   , fs = require("fs")
-  , generateTemplate = require("./util").generateTemplate
+  , generateTemplate = require("./support/generate_template")
 
 describe("An embedded model", function() {
   it("should set all the values in the html", function () {

--- a/test/enumerables.js
+++ b/test/enumerables.js
@@ -1,6 +1,8 @@
+require('./support/helper');
+
 var expect = require("expect.js")
   , fs = require("fs")
-  , generateTemplate = require("./util").generateTemplate
+  , generateTemplate = require("./support/generate_template")
 
 describe("An enumerable template", function() {
 

--- a/test/form_binding.js
+++ b/test/form_binding.js
@@ -1,8 +1,10 @@
+require('./support/helper');
+
 var path = require("path")
   , expect = require("expect.js")
   , fs = require("fs")
   , Backbone = require("backbone")
-  , generateTemplate = require("./util").generateTemplate
+  , generateTemplate = require("./support/generate_template")
 
 describe("when the template has an input", function() {
   it("should update the model when the DOM changes", function() {

--- a/test/get-selector.js
+++ b/test/get-selector.js
@@ -1,9 +1,9 @@
+require('./support/helper');
+
 var util = require("../lib/util")
   , path = require("path")
   , expect = require("expect.js")
   , fs = require("fs")
-
-require("./helper")
 
 describe("getSelector", function() {
   it("should return a selector unique within root", function() {

--- a/test/model_change.js
+++ b/test/model_change.js
@@ -1,11 +1,12 @@
-var generateTemplate = require("./util").generateTemplate
+require('./support/helper');
+
+var generateTemplate = require("./support/generate_template")
   , ViewReaction = require("../lib/reactions/view")
   , Backbone = require("backbone")
   , expect = require("expect.js")
   , _ = require("underscore")
   , fs = require("fs")
   , views = { }
-
 
 describe("When I replace an embedded model", function() {
   beforeEach(function() {

--- a/test/no-write.js
+++ b/test/no-write.js
@@ -1,8 +1,8 @@
+require('./support/helper');
+
 var Model = require("backbone").Model
   , expect = require("expect.js")
-  , generateTemplate = require("./util").generateTemplate
-
-require("./helper")
+  , generateTemplate = require("./support/generate_template")
 
 describe("An element with data-readonly", function() {
 

--- a/test/partials.js
+++ b/test/partials.js
@@ -1,3 +1,5 @@
+require('./support/helper');
+
 var path = require("path")
   , expect = require("expect.js")
   , fs = require("fs")
@@ -6,7 +8,7 @@ var path = require("path")
   , jqts = require("../lib/util").jqts
   , EndDash = require("../lib/end-dash")
   , TemplateStore = require('../lib/template_store')
-  , generateTemplate = require("./util").generateTemplate
+  , generateTemplate = require("./support/generate_template")
 
 describe("A template with partials", function() {
   it("should do collections", function() {

--- a/test/polymorphic_collections.js
+++ b/test/polymorphic_collections.js
@@ -1,8 +1,10 @@
+require('./support/helper');
+
 var path = require("path")
   , expect = require("expect.js")
   , fs = require("fs")
   , Backbone = require("backbone")
-  , generateTemplate = require("./util").generateTemplate
+  , generateTemplate = require("./support/generate_template")
 
 describe("A polymporhic template", function() {
 

--- a/test/scope_modifier.js
+++ b/test/scope_modifier.js
@@ -1,8 +1,8 @@
+require('./support/helper');
+
 var expect = require("expect.js")
   , fs = require("fs")
-  , generateTemplate = require("./util").generateTemplate
-
-require("./helper")
+  , generateTemplate = require("./support/generate_template")
 
 describe("An template", function() {
   describe("which has data-scope attributes", function() {

--- a/test/stop_observing.js
+++ b/test/stop_observing.js
@@ -1,10 +1,10 @@
+require('./support/helper');
+
 var path = require("path")
   , Model = require("backbone").Model
   , expect = require("expect.js")
   , fs = require("fs")
-  , generateTemplate = require("./util").generateTemplate
-
-require("./helper")
+  , generateTemplate = require("./support/generate_template")
 
 describe("When I clean up a template", function() { 
   it("should remove listeners from the model on a variable", function() {

--- a/test/support/generate_template.js
+++ b/test/support/generate_template.js
@@ -1,7 +1,7 @@
-var TemplateStore = require('../lib/template_store'),
+var TemplateStore = require('../../lib/template_store'),
     testTemplateCount = 0;
 
-exports.generateTemplate = function(model, markupOrPath) {
+module.exports = function(model, markupOrPath) {
   var Template, templatePath;
 
   if (markupOrPath.charAt(0) === '/') {

--- a/test/support/helper.js
+++ b/test/support/helper.js
@@ -1,10 +1,11 @@
-var jsdom = require("jsdom")
+var jsdom = require("jsdom");
 
 before(function(done) {
-  require('../lib/end-dash');
+  require('../../lib/end-dash');
+
   jsdom.env({
     html: "<html><head></head><body></body></html>",
-    scripts: [__dirname + "/../vendor/jquery.js"],
+    scripts: [__dirname + "/../../vendor/jquery.js"],
     done: jsDomLoaded
   })
 
@@ -17,6 +18,5 @@ before(function(done) {
     window.document.implementation.addFeature('ProcessExternalResources', ['script'])
     window.document.implementation.addFeature('MutationEvents', ['1.0'])
     done()
-
   }
 })

--- a/test/template_store.js
+++ b/test/template_store.js
@@ -1,3 +1,5 @@
+require('./support/helper');
+
 var expect = require("expect.js"),
     Parser = require('../lib/parser'),
     Template = require('../lib/template'),

--- a/test/variables.js
+++ b/test/variables.js
@@ -1,6 +1,8 @@
+require('./support/helper');
+
 var path = require("path")
   , expect = require("expect.js")
-  , generateTemplate = require("./util").generateTemplate
+  , generateTemplate = require("./support/generate_template")
   , Backbone = require('backbone')
 
 require("../lib/template")

--- a/test/view-construction.js
+++ b/test/view-construction.js
@@ -1,3 +1,5 @@
+require('./support/helper');
+
 var path = require("path")
   , expect = require("expect.js")
   , fs = require("fs")
@@ -5,10 +7,8 @@ var path = require("path")
   , ViewReaction = require("../lib/reactions/view")
   , Model = Backbone.Model
   , Collection = Backbone.Collection
-  , generateTemplate = require("./util").generateTemplate
+  , generateTemplate = require("./support/generate_template")
   , views = {}
-
-require("./helper")
 
 describe("When I initialize a template with a view bound to it", function() {
   beforeEach(function() {


### PR DESCRIPTION
@bglusman, trying to send PRs to someone other than topper code reviews since he's busy...

cc @devmanhinton, feel free to chime in if you have any comments as well!

Right now, our tests only work because we load `helper.js` as a test file. Instead, let's explicitly require it. This also provides a nice place to put test helpers.
