### PR TITLE
Make TemplateStore a factory rather than a singleton class.

### DIFF
--- a/lib/compile.js
+++ b/lib/compile.js
@@ -1,9 +1,8 @@
 // We're just keeping this around because base-backbone expects it to be here.
 // In the long run, we should probably not expose lib/compile.
-var TemplateStore = require('./template_store'),
-    EndDash = require('./end-dash'),
+var EndDash = require('./end-dash'),
     _ = require('underscore');
 
 var Compiler = EndDash.compile;
-Compiler.registerTemplate = TemplateStore.load;
+Compiler.registerTemplate = EndDash.templateStore.load;
 module.exports = Compiler;

--- a/lib/end-dash.js
+++ b/lib/end-dash.js
@@ -1,6 +1,6 @@
 var _ = require('underscore'),
     Parser = require('./parser'),
-    TemplateStore = require('./template_store'),
+    templateStore = require('./template_store').create(),
     AttributeReaction = require('./reactions/attribute'),
     CollectionReaction = require('./reactions/collection'),
     ModelReaction = require('./reactions/model'),
@@ -11,6 +11,8 @@ var _ = require('underscore'),
     ScopeReaction = require('./reactions/scope'),
     DebuggerReaction = require('./reactions/debugger');
 
+exports.templateStore = templateStore;
+
 // These two methods are exported simply because base-backbone expects them.
 // We should probably rework this interface at some point.
 exports.compile = function(module, filename) {
@@ -18,10 +20,10 @@ exports.compile = function(module, filename) {
       markup = fs.readFileSync(filename, 'utf8'),
       templateName = filename.replace(/\.js\.ed(\.erb)?$/, '');
 
-  module.exports = TemplateStore.loadAndParse(templateName, markup);
+  module.exports = templateStore.loadAndParse(templateName, markup);
 };
 
-exports.registerTemplate = TemplateStore.load;
+exports.registerTemplate = _.bind(templateStore.load, templateStore);
 
 Parser.registerReaction(PartialReaction);
 Parser.registerReaction(ScopeReaction);

--- a/lib/reactions/collection.js
+++ b/lib/reactions/collection.js
@@ -1,5 +1,5 @@
 var Parser = require("../parser")
-  , TemplateStore = require('../template_store')
+  , EndDash = require('../end-dash')
   , Reaction = require("../reaction")
   , inflection = require("inflection")
   , _ = require("underscore")
@@ -117,7 +117,7 @@ var CollectionReaction = Reaction.extend({
       var child = $(element)
         , whenValue = rules.polymorphicValue(child)
         , templatePath = _.last(state.pathStack)
-        , Template = TemplateStore.loadAndParse(templatePath+whenValue, child);
+        , Template = EndDash.templateStore.loadAndParse(templatePath+whenValue, child);
 
       templates[whenValue] = Template;
       child.remove()

--- a/lib/template_store.js
+++ b/lib/template_store.js
@@ -3,44 +3,42 @@
 var _ = require('underscore'),
     path = require('path'),
     Parser = require('./parser'),
-    TemplateStore = {},
-    RAW_TEMPLATES = {},
-    TEMPLATES = {};
+    TemplateStore = {};
 
 var pathToName = function(templatePath) {
   return path.normalize(templatePath);
 };
 
-var _parseTemplate = function(templatePath) {
+var _parseTemplate = function(templateStore, templatePath) {
   var name = pathToName(templatePath);
 
-  if (!TemplateStore.isLoaded(name)) {
+  if (!templateStore.isLoaded(name)) {
     throw new Error('Could not find template: '+name);
   }
 
-  var markup = RAW_TEMPLATES[name];
+  var markup = templateStore._RAW_TEMPLATES[name];
 
   return (new Parser(markup, {
     templateName: name,
-    templates: RAW_TEMPLATES
+    templates: templateStore._RAW_TEMPLATES
   })).generate();
 };
 
 TemplateStore.isLoaded = function(templatePath) {
-  return !!RAW_TEMPLATES[templatePath];
+  return !!this._RAW_TEMPLATES[templatePath];
 };
 
 TemplateStore.isParsed = function(templatePath) {
-  return !!TEMPLATES[templatePath];
+  return !!this._TEMPLATES[templatePath];
 };
 
 TemplateStore.load = function(templatePath, markup) {
   var name = pathToName(templatePath);
 
-  RAW_TEMPLATES[name] = markup;
+  this._RAW_TEMPLATES[name] = markup;
 
   if (this.isParsed(name)) {
-    delete TEMPLATES[name];
+    delete this._TEMPLATES[name];
   }
 };
 
@@ -53,16 +51,20 @@ TemplateStore.getTemplate = function(templatePath) {
   var name = pathToName(templatePath);
 
   if (!this.isParsed(name)) {
-    TEMPLATES[name] = _parseTemplate(name);
+    this._TEMPLATES[name] = _parseTemplate(this, name);
   }
 
-  return TEMPLATES[name];
+  return this._TEMPLATES[name];
 };
 
-_.bindAll(TemplateStore, 'isLoaded',
-                         'isParsed',
-                         'load',
-                         'loadAndParse',
-                         'getTemplate');
-
-module.exports = TemplateStore;
+exports.create = function() {
+  return {
+    _RAW_TEMPLATES: {},
+    _TEMPLATES: {},
+    isLoaded: TemplateStore.isLoaded,
+    isParsed: TemplateStore.isParsed,
+    load: TemplateStore.load,
+    loadAndParse: TemplateStore.loadAndParse,
+    getTemplate: TemplateStore.getTemplate
+  };
+};

--- a/test/partials.js
+++ b/test/partials.js
@@ -5,7 +5,6 @@ var path = require("path")
   , _ = require("underscore")
   , jqts = require("../lib/util").jqts
   , EndDash = require("../lib/end-dash")
-  , TemplateStore = require('../lib/template_store')
   , generateTemplate = require("./util").generateTemplate
 
 describe("A template with partials", function() {
@@ -22,10 +21,11 @@ describe("A template with partials", function() {
     }
 
     _(templates).each(function(template) {
-      TemplateStore.load(template, fs.readFileSync(__dirname + template).toString())
+      var templatePath = __dirname + template;
+      EndDash.templateStore.load(template, fs.readFileSync(templatePath).toString())
     })
 
-    var template = generateTemplate(model, '/support/partials.html')
+    var template = generateTemplate(model, '/support/partials.html', {shouldResetStore: false})
 
     expect($(".items- .item-:nth-child(1) .variable-").html()).to.be("wat1")
     expect($(".items- .item-:nth-child(2) .variable-").html()).to.be("wat2")

--- a/test/template_store.js
+++ b/test/template_store.js
@@ -1,16 +1,17 @@
 var expect = require("expect.js"),
     Parser = require('../lib/parser'),
     Template = require('../lib/template'),
-    TemplateStore = require('../lib/template_store'),
+    templateStore = require('../lib/template_store').create(),
+    _ = require('underscore'),
 
     // easier to read..
-    isLoaded = TemplateStore.isLoaded,
-    isParsed = TemplateStore.isParsed,
-    load = TemplateStore.load,
-    loadAndParse = TemplateStore.loadAndParse,
-    getTemplate = TemplateStore.getTemplate;
+    isLoaded = _.bind(templateStore.isLoaded, templateStore),
+    isParsed = _.bind(templateStore.isParsed, templateStore),
+    load = _.bind(templateStore.load, templateStore),
+    loadAndParse = _.bind(templateStore.loadAndParse, templateStore),
+    getTemplate = _.bind(templateStore.getTemplate, templateStore);
 
-describe('TemplateStore', function() {
+describe('templateStore', function() {
   describe('.load', function() {
     it('loads markup without parsing', function() {
       load('user', '<div id="user"></div>');

--- a/test/util.js
+++ b/test/util.js
@@ -1,16 +1,31 @@
-var TemplateStore = require('../lib/template_store'),
-    testTemplateCount = 0;
+var EndDash = require('../lib/end-dash'),
+    TemplateStore = require('../lib/template_store'),
+    testTemplateCount = 0,
+    _ = require('underscore');
 
-exports.generateTemplate = function(model, markupOrPath) {
-  var Template, templatePath;
+exports.resetStore = function() {
+  EndDash.templateStore = TemplateStore.create();
+};
+
+exports.generateTemplate = function(model, markupOrPath, options) {
+  options = _.extend({
+    shouldResetStore: true
+  }, options);
+
+  if (options.shouldResetStore) {
+    exports.resetStore();
+  };
+
+  var templateStore = EndDash.templateStore,
+      Template, templatePath;
 
   if (markupOrPath.charAt(0) === '/') {
     templatePath = markupOrPath;
-    Template = TemplateStore.getTemplate(templatePath);
+    Template = templateStore.getTemplate(templatePath);
 
   } else {
     templatePath = generateTestTemplatePath();
-    Template = TemplateStore.loadAndParse(templatePath, markupOrPath);
+    Template = templateStore.loadAndParse(templatePath, markupOrPath);
   }
 
   var template = new Template(model, {


### PR DESCRIPTION
Less global state! Just store the `templateStore` on the `EndDash` object. The test/util.js needs to be refactored after this, but that's lower priority.

@devmanhinton, @tobowers for review
