### PR TITLE
Clean up enddash public API.

### DIFF
--- a/docs/attribute_interpolation.markdown
+++ b/docs/attribute_interpolation.markdown
@@ -2,7 +2,7 @@
 ```coffeescript
 require("../test/support/helper")
 Model = require("backbone").Model
-EndDash = require("../lib/end-dash").generateTemplate
+EndDash = require("../lib/end-dash")
 ```
 ##Attribute Interpolation
 

--- a/docs/scopes.markdown
+++ b/docs/scopes.markdown
@@ -2,7 +2,7 @@
 ```coffeescript
 require("../test/support/helper")
 Model = require("Backbone").Model
-EndDash = require("../lib/end-dash").generateTemplate
+EndDash = require("../lib/end-dash")
 ```
 
 #Modifying the Scope

--- a/docs/variables.markdown
+++ b/docs/variables.markdown
@@ -6,7 +6,7 @@
 ```coffeescript
 require("../test/support/helper")
 Model = require("Backbone").Model
-EndDash = require("../lib/end-dash").generateTemplate
+EndDash = require("../lib/end-dash")
 ```
 The above code just imports test/support/helper and the backbone default model.
 

--- a/lib/end-dash.js
+++ b/lib/end-dash.js
@@ -1,19 +1,38 @@
 var _ = require('underscore'),
     Parser = require('./parser'),
     TemplateStore = require('./template_store'),
-    AttributeReaction = require('./reactions/attribute'),
-    CollectionReaction = require('./reactions/collection'),
-    ModelReaction = require('./reactions/model'),
-    VariableReaction = require('./reactions/variable'),
-    ConditionalReaction = require('./reactions/conditional'),
-    PartialReaction = require('./reactions/partial'),
-    ViewReaction = require('./reactions/view'),
-    ScopeReaction = require('./reactions/scope'),
-    DebuggerReaction = require('./reactions/debugger');
+    PageHelper = require('./page_helper'),
+    reactions = [
+      // The load order matters here...
+      require('./reactions/partial'),
+      require('./reactions/scope'),
+      require('./reactions/collection'),
+      require('./reactions/model'),
+      require('./reactions/attribute'),
+      require('./reactions/variable'),
+      require('./reactions/conditional'),
+      require('./reactions/view'),
+      require('./reactions/debugger')
+    ];
 
-// These two methods are exported simply because base-backbone expects them.
-// We should probably rework this interface at some point.
-exports.compile = function(module, filename) {
+_.each(reactions, Parser.registerReaction);
+
+module.exports = EndDash = {};
+
+EndDash.loadTemplatesFromPage = PageHelper.loadFromPage;
+EndDash.registerTemplate = TemplateStore.load;
+EndDash.getTemplateClass = TemplateStore.getTemplateClass;
+
+EndDash.getTemplate = function(templatePath, model) {
+  var Template = this.getTemplateClass(templatePath);
+  return new Template(model);
+}
+
+// This is a hack to make requiring a file that ends in .js.ed to return a
+// EndDash compiled version of that file. We need to expose it publicly,
+// because we have code that relies on it, but it's deprecated and not
+// officially a part of the public API.
+EndDash.compile = function(module, filename) {
   var fs = require('fs'),
       markup = fs.readFileSync(filename, 'utf8'),
       templateName = filename.replace(/\.js\.ed(\.erb)?$/, '');
@@ -21,19 +40,6 @@ exports.compile = function(module, filename) {
   module.exports = TemplateStore.loadAndParse(templateName, markup);
 };
 
-exports.registerTemplate = TemplateStore.load;
-
-Parser.registerReaction(PartialReaction);
-Parser.registerReaction(ScopeReaction);
-Parser.registerReaction(CollectionReaction);
-Parser.registerReaction(ModelReaction);
-Parser.registerReaction(AttributeReaction);
-Parser.registerReaction(VariableReaction);
-Parser.registerReaction(ConditionalReaction);
-Parser.registerReaction(ViewReaction);
-Parser.registerReaction(DebuggerReaction);
-
-// Necessary to magically override the require extensions.
 if (require.extensions && !require.extensions['.ed']) {
   require.extensions['.ed'] = require.extensions['.js.ed'] = exports.compile;
 }

--- a/lib/page_helper.js
+++ b/lib/page_helper.js
@@ -1,0 +1,20 @@
+var _ = require('underscore')
+  , templateStore = require('./template_store');
+
+// Only load HTML do not parse until template is requested
+// If this is changed be aware, order matters. If templates with
+// partials are parsed before their partials raw HTML are parser.js will error
+exports.loadFromPage = function () {
+  $('script[type="text/enddash"]').each(function() {
+    var $el = $(this),
+        // Need to trim whitespace or else jQuery will complain.
+        markup = $.trim($el.html()),
+        name = $el.attr('name');
+
+    if (!name) {
+      throw new Error("Script tags of type text/enddash must have a 'name' attribute");
+    }
+
+    templateStore.load($el.attr('name'), markup);
+  });
+};

--- a/lib/reactions/collection.js
+++ b/lib/reactions/collection.js
@@ -18,7 +18,7 @@ var CollectionReaction = Reaction.extend({
     }, this)
   },
 
-  getTemplate: function(model) {
+  getTemplateClass: function(model) {
     if (this.polymorphicKey) {
       var value = get(model, this.polymorphicKey)
       return this.itemTemplates[value]
@@ -28,7 +28,7 @@ var CollectionReaction = Reaction.extend({
   },
 
   add: function(model, index) {
-    var Template = this.getTemplate(model)
+    var Template = this.getTemplateClass(model)
       , template = new Template(model, { stack: this.stack.slice(0) })
       , children
 

--- a/lib/reactions/partial.js
+++ b/lib/reactions/partial.js
@@ -7,13 +7,19 @@ var Reaction = require("../reaction")
 var PartialReaction = Reaction.extend()
 
 PartialReaction.selector = "div[src], li[src], span[src]"
- 
+
 PartialReaction.preparse = function(el, state) {
   var src = el.attr("src")
     , file = path.resolve(state.currentDir(), src)
     , template = $(state.templates[file])
 
   if(!template.length) {
+    file = src = path.normalize(src)
+    // EndDash works with requirejs or <script type="text/enddash"> on a page.
+    template = $(state.templates[src])
+  }
+
+  if (!template.length) {
     throw new Error("could not find partial " + file + " in " +  _.last(state.pathStack))
   }
   state.pathStack.push(file)

--- a/lib/template.js
+++ b/lib/template.js
@@ -5,22 +5,26 @@ var Backbone               = require("backbone")
   , findDescendantsAndSelf = util.findDescendantsAndSelf
 
 function Template(model, opts) {
-  var stack
+  var stack;
 
-  opts = opts || {}
-  model = model || {}
-  this.stack = opts.stack || []
+  opts = opts || {};
+  model = model || {};
 
-  this.stack.push(model)
+  this.bound = false;
+  this.stack = opts.stack || [];
 
-  this.reactions = {}
-  this.getElement = _.memoize(this.getElement)
+  this.reactions = {};
+  this.getElement = _.memoize(this.getElement);
 
-  if(!this.markup) {
-    throw new Error("Created template without markup")
+  if (!this.markup) {
+    throw new Error("Created template without markup");
   }
-  this.template = this.markup.clone()
-  this.bind()
+
+  this.el = this.template = this.markup.clone(); // template is deprecated but used in some outside systems
+
+  if (model) {
+    this.bind(model);
+  }
 }
 
 Template.prototype.cleanup = function() {
@@ -34,17 +38,23 @@ Template.prototype.getElement = function(selector) {
   return findDescendantsAndSelf(this.template, selector)
 }
 
-Template.prototype.bind = function() {
+Template.prototype.bind = function(model) {
+  if (this.bound) {
+    throw new Error('Template already bound to a model.');
+  }
+
+  this.stack.push(model);
   this.traverse(this.structure, this.stack, function(el, reaction, stack, next) {
-    reaction.start(el, stack, next)
-  })
+    reaction.start(el, stack, next);
+  });
+
+  this.bound = true;
 }
 
 Template.prototype.traverse = function(structure, stack, callback, reload) {
-  var el = this.getElement(structure.selector)
-    , that = this
-    , reaction
-
+  var el = this.getElement(structure.selector),
+      that = this,
+      reaction;
 
   function next(stack, doReload) {
     _(structure.children).each(function(child) {

--- a/lib/template_store.js
+++ b/lib/template_store.js
@@ -46,16 +46,15 @@ TemplateStore.load = function(templatePath, markup) {
 
 TemplateStore.loadAndParse = function(templatePath, markup) {
   this.load(templatePath, markup);
-  return this.getTemplate(templatePath);
+  return this.getTemplateClass(templatePath);
 };
 
-TemplateStore.getTemplate = function(templatePath) {
+TemplateStore.getTemplateClass = function(templatePath) {
   var name = pathToName(templatePath);
 
   if (!this.isParsed(name)) {
     TEMPLATES[name] = _parseTemplate(name);
   }
-
   return TEMPLATES[name];
 };
 
@@ -63,6 +62,6 @@ _.bindAll(TemplateStore, 'isLoaded',
                          'isParsed',
                          'load',
                          'loadAndParse',
-                         'getTemplate');
+                         'getTemplateClass');
 
 module.exports = TemplateStore;

--- a/test/end-dash.js
+++ b/test/end-dash.js
@@ -1,0 +1,92 @@
+require('./support/helper');
+
+var expect = require('expect.js'),
+    Backbone = require('backbone'),
+    EndDash = require('../lib/end-dash'),
+    TemplateStore = require('../lib/template_store'),
+    Template = require('../lib/template'),
+    _ = require('underscore');
+
+describe('EndDash', function(){
+  describe('.registerTemplate', function() {
+    it('loads the template to the store', function(){
+      EndDash.registerTemplate('partials', '<div></div>');
+      expect(TemplateStore.isLoaded('partials')).to.be(true);
+    });
+  });
+
+  describe('.getTemplate', function() {
+    it('retrieves loaded templates', function() {
+      EndDash.registerTemplate('dog', '<div name="unbound-"></div>');
+      var template = EndDash.getTemplate('dog');
+      expect(template instanceof Template).to.be(true);
+      expect(template.el.text()).to.be('');
+    });
+
+    it('binds values from the model to the template', function() {
+      EndDash.registerTemplate('cat', '<div class="catName-"></div>');
+
+      var model = new Backbone.Model({catName: 'Alabama'}),
+          template = EndDash.getTemplate('cat', model);
+
+      expect(template.el.text()).to.be('Alabama');
+    });
+
+    it('tracks changes on the model after binding', function() {
+      EndDash.registerTemplate('goose', '<div class="gooseName-"></div>');
+
+      var model = new Backbone.Model({gooseName: 'Snowy'}),
+          template = EndDash.getTemplate('goose', model);
+
+      expect(template.el.text()).to.be('Snowy');
+      model.set('gooseName', 'Goosematix');
+      expect(template.el.text()).to.be('Goosematix');
+    });
+  });
+
+  describe('loadTemplatesFromPage', function() {
+    describe('when loaded correctly', function() {
+      before(function() {
+        var fs = require('fs');
+        window.document.body.innerHTML = fs.readFileSync(__dirname+'/support/templates/script_tags.js.ed');
+        EndDash.loadTemplatesFromPage();
+      });
+
+      it('loads templates from script tags', function() {
+        expect(TemplateStore.isLoaded('crow')).to.be(true);
+      });
+
+      it('does not load non-EndDash script tags', function() {
+        expect(TemplateStore.isLoaded('non-end-dash')).to.be(false);
+      });
+
+      describe('when retrieved with getTemplate', function() {
+        var template;
+
+        before(function() {
+          var model = new Backbone.Model({crowName: 'Caw'});
+          template = EndDash.getTemplate('crow', model);
+        });
+
+        it('returns a valid template', function() {
+          expect(template instanceof Template).to.be(true);
+        });
+
+        it('binds to a model correctly', function() {
+          expect(template.el.text()).to.be('Caw');
+        });
+      });
+    });
+
+    describe('when loaded without a name', function() {
+      before(function() {
+        var fs = require('fs');
+        window.document.body.innerHTML = fs.readFileSync(__dirname+'/support/templates/script_tags_without_name.js.ed');
+      });
+
+      it('errors if a name isn\'t provided', function() {
+        expect(EndDash.loadTemplatesFromPage).to.throwError(/must have a 'name' attribute/);
+      });
+    });
+  });
+});

--- a/test/support/generate_template.js
+++ b/test/support/generate_template.js
@@ -1,23 +1,24 @@
-var TemplateStore = require('../../lib/template_store'),
+var EndDash = require('../../lib/end-dash'),
+    TemplateStore = require('../../lib/template_store'),
+    PageHelper = require('../../lib/page_helper'),
     testTemplateCount = 0;
+
+  require('./helper');
 
 module.exports = function(model, markupOrPath) {
   var Template, templatePath;
 
   if (markupOrPath.charAt(0) === '/') {
     templatePath = markupOrPath;
-    Template = TemplateStore.getTemplate(templatePath);
 
   } else {
     templatePath = generateTestTemplatePath();
-    Template = TemplateStore.loadAndParse(templatePath, markupOrPath);
+    EndDash.registerTemplate(templatePath, markupOrPath);
   }
 
-  var template = new Template(model, {
-    templateName: templatePath+'.html'
-  });
-
+  var template = EndDash.getTemplate(templatePath, model);
   $('body').html(template.template);
+
   return template;
 }
 

--- a/test/support/templates/script_tags.js.ed
+++ b/test/support/templates/script_tags.js.ed
@@ -1,0 +1,7 @@
+<script type="text/enddash" name="crow">
+  <div class="crowName-"></div>
+</script>
+
+<script name="non-end-dash">
+  <p>This should not be loaded.</p>
+</script>

--- a/test/support/templates/script_tags_without_name.js.ed
+++ b/test/support/templates/script_tags_without_name.js.ed
@@ -1,0 +1,3 @@
+<script type="text/enddash">
+  <div class="mooseName-"></div>
+</script>

--- a/test/template_store.js
+++ b/test/template_store.js
@@ -10,7 +10,7 @@ var expect = require("expect.js"),
     isParsed = TemplateStore.isParsed,
     load = TemplateStore.load,
     loadAndParse = TemplateStore.loadAndParse,
-    getTemplate = TemplateStore.getTemplate;
+    getTemplateClass = TemplateStore.getTemplateClass;
 
 describe('TemplateStore', function() {
   describe('.load', function() {
@@ -21,17 +21,17 @@ describe('TemplateStore', function() {
     });
   });
 
-  describe('.getTemplate', function() {
+  describe('.getTemplateClass', function() {
     it('retrieves loaded templates', function() {
       load('user', '<div id="user"></div>');
-      var UserTemplate = getTemplate('user');
+      var UserTemplate = getTemplateClass('user');
       expect(UserTemplate).to.be.a(Template.constructor);
     });
 
     it('returns the same Template object when called repeatedly', function() {
       load('user', '<div id="user"></div>');
-      var UserTemplate = getTemplate('user'),
-          UserTemplate2 = getTemplate('user');
+      var UserTemplate = getTemplateClass('user'),
+          UserTemplate2 = getTemplateClass('user');
 
       expect(UserTemplate2).to.equal(UserTemplate);
     });
@@ -39,14 +39,14 @@ describe('TemplateStore', function() {
     it('retrieves templates using a normalized path', function() {
       var BarTemplate = loadAndParse('/foo/bar', '<div id="bar"></div>');
 
-      expect(getTemplate('/foo/bar')).to.equal(BarTemplate);
-      expect(getTemplate('/foo/bar/baz/..')).to.equal(BarTemplate);
-      expect(getTemplate('/foo/baz/../bar')).to.equal(BarTemplate);
+      expect(getTemplateClass('/foo/bar')).to.equal(BarTemplate);
+      expect(getTemplateClass('/foo/bar/baz/..')).to.equal(BarTemplate);
+      expect(getTemplateClass('/foo/baz/../bar')).to.equal(BarTemplate);
     });
 
     it('errors when it can\'t find a template', function() {
       expect(function() {
-        getTemplate('notLoaded')
+        getTemplateClass('notLoaded')
       }).to.throwError(/Could not find template/);
     });
 
@@ -54,7 +54,7 @@ describe('TemplateStore', function() {
       load('user', '<div id="user"></div>');
 
       expect(isParsed('user')).to.be(false);
-      getTemplate('user');
+      getTemplateClass('user');
       expect(isParsed('user')).to.be(true);
     });
   });


### PR DESCRIPTION
Hi @devmanhinton, @tobowers 

We reworked the EndDash public API and made it ready to be used by a developer. We need to add documentation and an example application, which we'll do Today and Monday (a day or two behind because we've both been on emergency stuff). A quick summary:

``` javascript
// Load templates from <script type="text/enddash"></script> on
// the page.
EndDash.loadTemplatesFromPage = PageHelper.loadFromPage;

// Add a template to the store. Do not parse it.
EndDash.registerTemplate = TemplateStore.load;

// Retrieve a template class. Brief uses this. We should try to
// deprecate this and push people towards `getTemplate`
EndDash.getTemplateClass = TemplateStore.getTemplateClass;

// Retrieve a template instance, optionally bound to a model.
EndDash.getTemplate = function(templatePath, model) {
  var Template = this.getTemplateClass(templatePath);
  return new Template(model);
}
```

If this is good, we should merge it and make it work with brief.
