### PR TITLE
Bump version in preparation to merge with brief.

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,6 +1,6 @@
 {
   "name": "end-dash",
-  "version": "0.2.11",
+  "version": "0.3.0",
   "main": "./lib/end-dash.js",
   "dependencies": {
     "jquery": "1.8.x",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "end-dash",
   "description": "",
-  "version": "0.2.11",
+  "version": "0.3.0",
   "repository": {
     "type": "git",
     "url": "git://github.com/Amicus/end-dash.git"


### PR DESCRIPTION
@tobowers cc @devmanhinton 

v0.3.0

Breaking changes:
- `EndDash.getTemplate` now returns an instance of a Template rather
  than the class itself.
