### PR TITLE
Fix diff backbone issue

### DIFF
--- a/lib/reactions/model.js
+++ b/lib/reactions/model.js
@@ -9,7 +9,7 @@ var ModelReaction = Reaction.extend({
   init: function(next, reload) {
     var newModel = this.get(this.modelName);
     if(!(newModel instanceof Backbone.Model || newModel instanceof Backbone.Collection ||
-          this.isEndDashCompatbile(newModel))) {
+          this.isEndDashCompatible(newModel))) {
       newModel = new Backbone.Model(newModel || {});
     }
 
@@ -18,7 +18,7 @@ var ModelReaction = Reaction.extend({
     next(reload);
   },
 
-  isEndDashCompatbile: function(model) {
+  isEndDashCompatible: function(model) {
     return (typeof model.on == 'function' &&
             typeof model.once == 'function' &&
             typeof model.set == 'function' &&

--- a/lib/reactions/model.js
+++ b/lib/reactions/model.js
@@ -2,23 +2,23 @@ var Reaction = require("../reaction")
   , rules = require("../rules")
   , path = require("path")
   , Backbone = require("backbone")
-  , _ = require("underscore")
+  , _ = require("underscore");
 
 var ModelReaction = Reaction.extend({
 
   init: function(next, reload) {
-    var newModel = this.get(this.modelName)
+    var newModel = this.get(this.modelName);
     if(!(newModel instanceof Backbone.Model || newModel instanceof Backbone.Collection ||
-          this.isEndDashCompatabile(newModel))) {
-      newModel = new Backbone.Model(newModel || {})
+          this.isEndDashCompatbile(newModel))) {
+      newModel = new Backbone.Model(newModel || {});
     }
 
-    this.el.data("model", newModel)
-    this.stack.push(newModel)
-    next(reload)
+    this.el.data("model", newModel);
+    this.stack.push(newModel);
+    next(reload);
   },
 
-  isEndDashCompatabile: function(model) {
+  isEndDashCompatbile: function(model) {
     return (typeof model.on == 'function' &&
             typeof model.once == 'function' &&
             typeof model.set == 'function' &&
@@ -28,16 +28,16 @@ var ModelReaction = Reaction.extend({
 
   observe: function(next) {
     this.change(this.modelName, function(model) {
-      this.init(next, true)
-    }, this)
+      this.init(next, true);
+    }, this);
     if(this.el.is("form")) {
       this.uiEvent("submit", function(e) {
-        var objectToSave = this.stack[this.stack.length - 1]
+        var objectToSave = this.stack[this.stack.length - 1];
         if (objectToSave.save && objectToSave.save.apply) {
-          objectToSave.save()
+          objectToSave.save();
         }
-        e.preventDefault()
-      }, this)
+        e.preventDefault();
+      }, this);
     }
   }
 
@@ -56,4 +56,4 @@ var ModelReaction = Reaction.extend({
   }
 })
 
-module.exports = ModelReaction
+module.exports = ModelReaction;

--- a/lib/reactions/model.js
+++ b/lib/reactions/model.js
@@ -26,7 +26,7 @@ var ModelReaction = Reaction.extend({
             typeof model.once == 'function' &&
             typeof model.set == 'function' &&
             typeof model.get == 'function'
-           )
+           );
   },
 
   observe: function(next) {
@@ -48,15 +48,15 @@ var ModelReaction = Reaction.extend({
   selector: "[class]",
 
   reactIf: function(el) {
-    return rules.model(el)
+    return rules.model(el);
   },
 
   parse: function(el, state) {
     return {
       modelName: rules.model(el),
       currentDirectory: state.currentDir()
-    }
+    };
   }
-})
+});
 
 module.exports = ModelReaction;

--- a/lib/reactions/model.js
+++ b/lib/reactions/model.js
@@ -8,14 +8,22 @@ var ModelReaction = Reaction.extend({
 
   init: function(next, reload) {
     var newModel = this.get(this.modelName)
-
-    if(!(newModel instanceof Backbone.Model || newModel instanceof Backbone.Collection)) {
+    if(!(newModel instanceof Backbone.Model || newModel instanceof Backbone.Collection ||
+          this.isEndDashCompatabile(newModel))) {
       newModel = new Backbone.Model(newModel || {})
     }
 
     this.el.data("model", newModel)
     this.stack.push(newModel)
     next(reload)
+  },
+
+  isEndDashCompatabile: function(model) {
+    return (typeof model.on == 'function' &&
+            typeof model.once == 'function' &&
+            typeof model.set == 'function' &&
+            typeof model.get == 'function'
+           )
   },
 
   observe: function(next) {

--- a/lib/reactions/model.js
+++ b/lib/reactions/model.js
@@ -19,6 +19,9 @@ var ModelReaction = Reaction.extend({
   },
 
   isEndDashCompatible: function(model) {
+    if (!model) {
+      return false;
+    }
     return (typeof model.on == 'function' &&
             typeof model.once == 'function' &&
             typeof model.set == 'function' &&

--- a/test/non_backbone_integration.js
+++ b/test/non_backbone_integration.js
@@ -10,180 +10,181 @@ delete require.cache[require.resolve('Backbone')];
 var BackboneClone = require('Backbone');// Internally we use !(model instanceof Backbone.Model || ... instanceof Backbone.Collection)
                                         // If the Backbone for EndDash is different then the clients, we want to handle this case.
                                         // See lib/reactions/model.js for fix.
-
-describe("With a backbone model from a different backbone object", function(){
-  it("binding it to a template should work normally", function(){
-    var model = new BackboneClone.Model({persisted: "Chelsa Piers"})
-      , template = generateTemplate({user: model}, "<div class='user-'><div class='persisted-'></div></div>");
-
-    expect($('.persisted-').html()).to.be('Chelsa Piers');
-    model.set('persisted', 'Changed');
-    expect($('.persisted-').html()).to.be('Changed');
-  })
-})
-
-describe("With a backbone model", function(){
+describe("With a set of models, collections, and a template", function(){
   beforeEach(function(){
-    var backModel = new Backbone.Model();
+    this.literalModel1 = {persisted: "Chelsa Piers", hook: '1'}
+    this.literalModel2 = {persisted: "Columbus circle", hook: '2'}
+    this.literalModel3 = {persisted: "Soho", hook: '3'};
+    this.cloneModel1 = new BackboneClone.Model({persisted: "Chelsa Piers", hook: '1'})
+    this.cloneModel2 = new BackboneClone.Model({persisted: "Columbus circle", hook: '2'})
+    this.cloneModel3 = new BackboneClone.Model({persisted: "Soho", hook: '3'});
+    this.backboneModel1 = new Backbone.Model({persisted: "Chelsa Piers", hook: '1'})
+    this.backboneModel2 = new Backbone.Model({persisted: "Columbus circle", hook: '2'})
+    this.backboneModel3 = new Backbone.Model({persisted: "Soho", hook: '3'});
+    this.modelHTMLTemplate = "<div class='user-'>" +
+                                "<div class='persisted-'>" +
+                                "</div>" +
+                              "</div>";
+    this.collectionHTMLTemplate = "<div class='users-'>" +
+                                    "<div class ='user-'>" +
+                                      "<div class=' #{hook} persisted-'>" +
+                                      "</div>" +
+                                    "</div>" +
+                                  "</div>";
   })
-  it("binding it to a template should work normally", function(){
-    var model = new Backbone.Model({persisted: "Chelsa Piers"})
-      , template = generateTemplate({user: model}, "<div class='user-'><div class='persisted-'></div></div>");
 
-    expect($('.persisted-').html()).to.be('Chelsa Piers');
-    model.set('persisted', 'Changed');
-    expect($('.persisted-').html()).to.be('Changed');
+  describe("binding a backbone model from a different backbone object", function(){
+    beforeEach(function(){
+      this.template = generateTemplate({user: this.cloneModel1}, this.modelHTMLTemplate)
+    })
+    it("should interpolate the model's attribute into the html", function(){
+      expect($('.persisted-').html()).to.be('Chelsa Piers');
+    })
+    it("should update the corrosponding attribute", function(){
+      this.cloneModel1.set('persisted', 'Changed');
+      expect($('.persisted-').html()).to.be('Changed');
+    })
+  })
+
+  describe("With a backbone model", function(){
+    it("binding it to a template should work normally", function(){
+      var template = generateTemplate({user: this.backboneModel1}, this.modelHTMLTemplate);
+      expect($('.persisted-').html()).to.be('Chelsa Piers');
+      this.backboneModel1.set('persisted', 'Changed');
+      expect($('.persisted-').html()).to.be('Changed');
+    })
+  })
+
+  describe("With a backbone collection from a different backbone object", function(){
+    beforeEach(function(){
+      this.collection = new BackboneClone.Collection();
+    })
+    describe("With models from a different backbone object", function(){
+      it("binding the collection and models to a template should work normally", function(){
+        this.collection.add([this.cloneModel1, this.cloneModel2, this.cloneModel3]);
+        var template = generateTemplate({users: this.collection}, this.collectionHTMLTemplate);
+        expect($('.1').html()).to.be(this.cloneModel1.get('persisted'));
+        expect($('.2').html()).to.be(this.cloneModel2.get('persisted'));
+        expect($('.3').html()).to.be(this.cloneModel3.get('persisted'));
+        this.cloneModel1.set('persisted', 'Changed1');
+        this.cloneModel2.set('persisted', 'Changed2');
+        this.cloneModel3.set('persisted', 'Changed3');
+        expect($('.1').html()).to.be(this.cloneModel1.get('persisted'));
+        expect($('.2').html()).to.be(this.cloneModel2.get('persisted'));
+        expect($('.3').html()).to.be(this.cloneModel3.get('persisted'));
+      })
+    })
+
+    describe("With anonymous models, binding the collection and models to a template ", function(){
+      it("should interpolate values but not update on model changes", function(){
+        this.collection.add([this.literalModel1, this.literalModel2, this.literalModel3]);
+        var template = generateTemplate({users: this.collection}, this.collectionHTMLTemplate);
+        expect($('.1').html()).to.be(this.literalModel1.persisted);
+        expect($('.2').html()).to.be(this.literalModel2.persisted);
+        expect($('.3').html()).to.be(this.literalModel3.persisted);
+        this.literalModel1.persisted = 'Changed1';
+        this.literalModel2.persisted = 'Changed2';
+        this.literalModel3.persisted = 'Changed3';
+        expect($('.1').html()).to.be("Chelsa Piers");
+        expect($('.2').html()).to.be("Columbus circle");
+        expect($('.3').html()).to.be("Soho");
+      })
+    })
+
+    describe("With a mix of different model kinds", function(){
+      it("binding them to a template should still work for each as expected", function(){
+        this.collection.add([this.cloneModel1, this.literalModel2, this.backboneModel3]);
+        var template = generateTemplate({users: this.collection}, this.collectionHTMLTemplate);
+        expect($('.1').html()).to.be(this.cloneModel1.get('persisted'));
+        expect($('.2').html()).to.be(this.literalModel2.persisted);
+        expect($('.3').html()).to.be(undefined);
+        this.cloneModel1.set('persisted', 'Changed1');
+        this.literalModel2.persisted = 'Changed2';
+        this.backboneModel3.set('persisted', 'Changed3');
+        expect($('.1').html()).to.be(this.cloneModel1.get('persisted'));
+        expect($('.2').html()).to.be("Columbus circle");
+        expect($('.3').html()).to.be(undefined);
+      })
+    })
+  })
+
+
+  describe("With a backbone collection from the same backbone object", function(){
+    beforeEach(function(){
+      this.collection = new Backbone.Collection();
+    })
+
+    describe("With models from a different backbone object", function(){
+      it("Binding them to a template should not work properly", function(){
+        this.collection.add([this.cloneModel1, this.cloneModel2, this.cloneModel3]);
+        var template = generateTemplate({users: this.collection}, this.collectionHTMLTemplate);
+        expect($('.1').html()).to.be(undefined);
+        expect($('.2').html()).to.be(undefined);
+        expect($('.3').html()).to.be(undefined);
+        this.cloneModel1.set('persisted', 'Changed1');
+        this.cloneModel2.set('persisted', 'Changed2');
+        this.cloneModel3.set('persisted', 'Changed3');
+        expect($('.1').html()).to.be(undefined);
+        expect($('.2').html()).to.be(undefined);
+        expect($('.3').html()).to.be(undefined);
+      })
+    })
+
+    describe("With models from the same backbone object", function(){
+      it("binding them to a template should work normally", function(){
+        this.collection.add([this.backboneModel1, this.backboneModel2, this.backboneModel3]);
+        var template = generateTemplate({users: this.collection}, this.collectionHTMLTemplate);
+        expect($('.1').html()).to.be(this.backboneModel1.get('persisted'));
+        expect($('.2').html()).to.be(this.backboneModel2.get('persisted'));
+        expect($('.3').html()).to.be(this.backboneModel3.get('persisted'));
+        this.backboneModel1.set('persisted', 'Changed1');
+        this.backboneModel2.set('persisted', 'Changed2');
+        this.backboneModel3.set('persisted', 'Changed3');
+        expect($('.1').html()).to.be(this.backboneModel1.get('persisted'));
+        expect($('.2').html()).to.be(this.backboneModel2.get('persisted'));
+        expect($('.3').html()).to.be(this.backboneModel3.get('persisted'));
+      })
+    })
+
+    describe("With anonymous models binding the collection/models to a template ", function(){
+      it("should still interpolate values but changes will not be updated", function(){
+        this.collection.add([this.literalModel1, this.literalModel2, this.literalModel3]);
+        var template = generateTemplate({users: this.collection}, this.collectionHTMLTemplate);
+        expect($('.1').html()).to.be(this.literalModel1.persisted);
+        expect($('.2').html()).to.be(this.literalModel2.persisted);
+        expect($('.3').html()).to.be(this.literalModel3.persisted);
+        this.literalModel1.persisted = 'Changed1';
+        this.literalModel2.persisted = 'Changed2';
+        this.literalModel3.persisted = 'Changed3';
+        expect($('.1').html()).to.be("Chelsa Piers");
+        expect($('.2').html()).to.be("Columbus circle");
+        expect($('.3').html()).to.be("Soho");
+      })
+    })
+
+    describe("With a mix of different model kinds", function(){
+      it("binding them to a template should still work for each type as expected", function(){
+        this.collection.add([this.backboneModel1, this.literalModel2, this.cloneModel3]);
+        var template = generateTemplate({users: this.collection}, this.collectionHTMLTemplate);
+        expect($('.1').html()).to.be(this.backboneModel1.get('persisted'));
+        expect($('.2').html()).to.be(this.literalModel2.persisted);
+        expect($('.3').html()).to.be(undefined);
+        this.backboneModel1.set('persisted', 'Changed1');
+        this.literalModel2.persisted = 'Changed2';
+        this.cloneModel3.set('persisted', 'Changed3');
+        expect($('.1').html()).to.be(this.backboneModel1.get('persisted'));
+        expect($('.2').html()).to.be("Columbus circle");
+        expect($('.3').html()).to.be(undefined);
+      })
+    })
   })
 })
 
-describe("With a backbone collection from a different backbone object", function(){
-  beforeEach(function(){
-    this.collection = new BackboneClone.Collection();
-    this.templateString = "<div class='users-'><div class ='user-'><div class=' #{hook} persisted-'></div></div></div>";
-  })
 
-  describe("With models from a different backbone object", function(){
-    it("binding the collection and models to a template should work normally", function(){
-      var model1 = new BackboneClone.Model({persisted: "Chelsa Piers", hook: '1'})
-        , model2 = new BackboneClone.Model({persisted: "Columbus circle", hook: '2'})
-        , model3 = new BackboneClone.Model({persisted: "Soho", hook: '3'});
-      this.collection.add([model1, model2, model3]);
-      var template = generateTemplate({users: this.collection}, this.templateString);
-      expect($('.1').html()).to.be(model1.get('persisted'));
-      expect($('.2').html()).to.be(model2.get('persisted'));
-      expect($('.3').html()).to.be(model3.get('persisted'));
-      model1.set('persisted', 'Changed1');
-      model2.set('persisted', 'Changed2');
-      model3.set('persisted', 'Changed3');
-      expect($('.1').html()).to.be(model1.get('persisted'));
-      expect($('.2').html()).to.be(model2.get('persisted'));
-      expect($('.3').html()).to.be(model3.get('persisted'));
-    })
-  })
 
-  describe("With anonymous models, binding the collection and models to a template ", function(){
-    it("should interpolate values but not update on model changes", function(){
-      var model1 = {persisted: "Chelsa Piers", hook: '1'}
-        , model2 = {persisted: "Columbus circle", hook: '2'}
-        , model3 = {persisted: "Soho", hook: '3'};
-      this.collection.add([model1, model2, model3]);
-      var template = generateTemplate({users: this.collection}, this.templateString);
-      expect($('.1').html()).to.be(model1.persisted);
-      expect($('.2').html()).to.be(model2.persisted);
-      expect($('.3').html()).to.be(model3.persisted);
-      model1.persisted = 'Changed1';
-      model2.persisted = 'Changed2';
-      model3.persisted = 'Changed3';
-      expect($('.1').html()).to.be("Chelsa Piers");
-      expect($('.2').html()).to.be("Columbus circle");
-      expect($('.3').html()).to.be("Soho");
-    })
-  })
 
-  describe("With a mix of different model kinds", function(){
-    it("binding them to a template should still work for each as expected", function(){
-      var model1 = new BackboneClone.Model({persisted: "Chelsa Piers", hook: '1'})
-        , model2 = {persisted: "Columbus circle", hook: '2'}
-        , model3 = new Backbone.Model({persisted: "Soho", hook: '3'});
-      this.collection.add([model1, model2, model3]);
-      var template = generateTemplate({users: this.collection}, this.templateString);
-      expect($('.1').html()).to.be(model1.get('persisted'));
-      expect($('.2').html()).to.be(model2.persisted);
-      expect($('.3').html()).to.be(undefined);
-      model1.set('persisted', 'Changed1');
-      model2.persisted = 'Changed2';
-      model3.set('persisted', 'Changed3');
-      expect($('.1').html()).to.be(model1.get('persisted'));
-      expect($('.2').html()).to.be("Columbus circle");
-      expect($('.3').html()).to.be(undefined);
-    })
-  })
-})
 
-describe("With a backbone collection from the same backbone object", function(){
-  beforeEach(function(){
-    this.collection = new Backbone.Collection();
-    this.templateString = "<div class='users-'>" +
-                            "<div class ='user-'>" +
-                              "<div class=' #{hook} persisted-'>" +
-                              "</div>" +
-                            "</div>" +
-                          "</div>";
-  })
 
-  describe("With models from a different backbone object", function(){
-    it("Binding them to a template should not work properly", function(){
-      var model1 = new BackboneClone.Model({persisted: "Chelsa Piers", hook: '1'})
-        , model2 = new BackboneClone.Model({persisted: "Columbus circle", hook: '2'})
-        , model3 = new BackboneClone.Model({persisted: "Soho", hook: '3'});
-      this.collection.add([model1, model2, model3]);
-      var template = generateTemplate({users: this.collection}, this.templateString);
-      expect($('.1').html()).to.be(undefined);
-      expect($('.2').html()).to.be(undefined);
-      expect($('.3').html()).to.be(undefined);
-      model1.set('persisted', 'Changed1');
-      model2.set('persisted', 'Changed2');
-      model3.set('persisted', 'Changed3');
-      expect($('.1').html()).to.be(undefined);
-      expect($('.2').html()).to.be(undefined);
-      expect($('.3').html()).to.be(undefined);
-    })
-  })
 
-  describe("With models from the same backbone object", function(){
-    it("binding them to a template should work normally", function(){
-      var model1 = new Backbone.Model({persisted: "Chelsa Piers", hook: '1'})
-        , model2 = new Backbone.Model({persisted: "Columbus circle", hook: '2'})
-        , model3 = new Backbone.Model({persisted: "Soho", hook: '3'});
-      this.collection.add([model1, model2, model3]);
-      var template = generateTemplate({users: this.collection}, this.templateString);
-      expect($('.1').html()).to.be(model1.get('persisted'));
-      expect($('.2').html()).to.be(model2.get('persisted'));
-      expect($('.3').html()).to.be(model3.get('persisted'));
-      model1.set('persisted', 'Changed1');
-      model2.set('persisted', 'Changed2');
-      model3.set('persisted', 'Changed3');
-      expect($('.1').html()).to.be(model1.get('persisted'));
-      expect($('.2').html()).to.be(model2.get('persisted'));
-      expect($('.3').html()).to.be(model3.get('persisted'));
-    })
-  })
 
-  describe("With anonymous models binding the collection/models to a template ", function(){
-    it("should still interpolate values but changes will not be updated", function(){
-      var model1 = {persisted: "Chelsa Piers", hook: '1'}
-        , model2 = {persisted: "Columbus circle", hook: '2'}
-        , model3 = {persisted: "Soho", hook: '3'};
-      this.collection.add([model1, model2, model3]);
-      var template = generateTemplate({users: this.collection}, this.templateString);
-      expect($('.1').html()).to.be(model1.persisted);
-      expect($('.2').html()).to.be(model2.persisted);
-      expect($('.3').html()).to.be(model3.persisted);
-      model1.persisted = 'Changed1';
-      model2.persisted = 'Changed2';
-      model3.persisted = 'Changed3';
-      expect($('.1').html()).to.be("Chelsa Piers");
-      expect($('.2').html()).to.be("Columbus circle");
-      expect($('.3').html()).to.be("Soho");
-    })
-  })
 
-  describe("With a mix of different model kinds", function(){
-    it("binding them to a template should still work for each type as expected", function(){
-      var model1 = new Backbone.Model({persisted: "Chelsa Piers", hook: '1'})
-        , model2 = {persisted: "Columbus circle", hook: '2'}
-        , model3 = new BackboneClone.Model({persisted: "Soho", hook: '3'});
-      this.collection.add([model1, model2, model3]);
-      var template = generateTemplate({users: this.collection}, this.templateString);
-      expect($('.1').html()).to.be(model1.get('persisted'));
-      expect($('.2').html()).to.be(model2.persisted);
-      expect($('.3').html()).to.be(undefined);
-      model1.set('persisted', 'Changed1');
-      model2.persisted = 'Changed2';
-      model3.set('persisted', 'Changed3');
-      expect($('.1').html()).to.be(model1.get('persisted'));
-      expect($('.2').html()).to.be("Columbus circle");
-      expect($('.3').html()).to.be(undefined);
-    })
-  })
-})

--- a/test/non_backbone_integration.js
+++ b/test/non_backbone_integration.js
@@ -1,0 +1,39 @@
+require('./support/helper');
+
+var path = require("path")
+  , expect = require("expect.js")
+  , fs = require("fs")
+  , generateTemplate = require("./support/generate_template")
+  , Backbone = require('Backbone')
+  , modelReaction = require('../lib/reactions/model')
+
+
+describe("When dealing with models that are not Backbone models but support the functionality we need", function(){
+  beforeEach(function(){
+    var backModel = new Backbone.Model()
+    this.supportedModel = function(){
+      this.name = "supportedModel"
+      this.get = function(key){return this.key}
+      this.set = function(key, value ){this.key = value}
+      this.on = function(){}
+      this.once = function(){}
+    }
+  })
+  it("Should not force my model to be a Backbone model", function(){
+    var model = new this.supportedModel()
+    var template = generateTemplate({user: model}, "<div class='user-'><div class='name-'></div></div>")
+  })
+})
+
+describe("When dealing with models that are not Backbone models and do not support the functionality we need", function(){
+  beforeEach(function(){
+    var backModel = new Backbone.Model()
+    this.unSupportedModel = function(){
+      this.name = "unsupportedModel"
+    }
+  })
+  it("Should force my model to be a Backbone model", function(){
+    var model = new this.unSupportedModel()
+    var template = generateTemplate({user: model}, "<div class='user-'><div class='name-'></div></div>")
+  })
+})

--- a/test/non_backbone_integration.js
+++ b/test/non_backbone_integration.js
@@ -12,7 +12,7 @@ var BackboneClone = require('Backbone') // Internally we use !(model instanceof 
                                         // See lib/reactions/model.js for fix.
 
 describe("With a backbone model from a different backbone object", function(){
-  it("Should still work properly", function(){
+  it("binding it to a template should work normally", function(){
     var model = new BackboneClone.Model({persisted: "Chelsa Piers"})
       , template = generateTemplate({user: model}, "<div class='user-'><div class='persisted-'></div></div>")
 
@@ -26,7 +26,7 @@ describe("With a backbone model", function(){
   beforeEach(function(){
     var backModel = new Backbone.Model()
   })
-  it("Should work as normal", function(){
+  it("binding it to a template should work normally", function(){
     var model = new Backbone.Model({persisted: "Chelsa Piers"})
       , template = generateTemplate({user: model}, "<div class='user-'><div class='persisted-'></div></div>")
 
@@ -43,7 +43,7 @@ describe("With a backbone collection from a different backbone object", function
   })
 
   describe("With models from a different backbone object", function(){
-    it("Should still work properly", function(){
+    it("binding the collection and models to a template should work normally", function(){
       var model1 = new BackboneClone.Model({persisted: "Chelsa Piers", hook: '1'})
         , model2 = new BackboneClone.Model({persisted: "Columbus circle", hook: '2'})
         , model3 = new BackboneClone.Model({persisted: "Soho", hook: '3'})
@@ -61,8 +61,8 @@ describe("With a backbone collection from a different backbone object", function
     })
   })
 
-  describe("With anonymous models", function(){
-    it("Should still interpolate values but changes will not be updated", function(){
+  describe("With anonymous models, binding the collection and models to a template ", function(){
+    it("should interpolate values but not update on model changes", function(){
       var model1 = {persisted: "Chelsa Piers", hook: '1'}
         , model2 = {persisted: "Columbus circle", hook: '2'}
         , model3 = {persisted: "Soho", hook: '3'}
@@ -81,7 +81,7 @@ describe("With a backbone collection from a different backbone object", function
   })
 
   describe("With a mix of different model kinds", function(){
-    it("Should still work properly", function(){
+    it("binding them to a template should still work for each as expected", function(){
       var model1 = new BackboneClone.Model({persisted: "Chelsa Piers", hook: '1'})
         , model2 = {persisted: "Columbus circle", hook: '2'}
         , model3 = new Backbone.Model({persisted: "Soho", hook: '3'})
@@ -107,7 +107,7 @@ describe("With a backbone collection from the same backbone object", function(){
   })
 
   describe("With models from a different backbone object", function(){
-    it("Does not work properly", function(){
+    it("Binding them to a template should not work properly", function(){
       var model1 = new BackboneClone.Model({persisted: "Chelsa Piers", hook: '1'})
         , model2 = new BackboneClone.Model({persisted: "Columbus circle", hook: '2'})
         , model3 = new BackboneClone.Model({persisted: "Soho", hook: '3'})
@@ -126,7 +126,7 @@ describe("With a backbone collection from the same backbone object", function(){
   })
 
   describe("With models from the same backbone object", function(){
-    it("Does not work properly", function(){
+    it("binding them to a template should work normally", function(){
       var model1 = new Backbone.Model({persisted: "Chelsa Piers", hook: '1'})
         , model2 = new Backbone.Model({persisted: "Columbus circle", hook: '2'})
         , model3 = new Backbone.Model({persisted: "Soho", hook: '3'})
@@ -144,8 +144,8 @@ describe("With a backbone collection from the same backbone object", function(){
     })
   })
 
-  describe("With anonymous models", function(){
-    it("Should still interpolate values but changes will not be updated", function(){
+  describe("With anonymous models binding the collection/models to a template ", function(){
+    it("should still interpolate values but changes will not be updated", function(){
       var model1 = {persisted: "Chelsa Piers", hook: '1'}
         , model2 = {persisted: "Columbus circle", hook: '2'}
         , model3 = {persisted: "Soho", hook: '3'}
@@ -164,7 +164,7 @@ describe("With a backbone collection from the same backbone object", function(){
   })
 
   describe("With a mix of different model kinds", function(){
-    it("Should still work properly", function(){
+    it("binding them to a template should still work for each type as expected", function(){
       var model1 = new Backbone.Model({persisted: "Chelsa Piers", hook: '1'})
         , model2 = {persisted: "Columbus circle", hook: '2'}
         , model3 = new BackboneClone.Model({persisted: "Soho", hook: '3'})

--- a/test/non_backbone_integration.js
+++ b/test/non_backbone_integration.js
@@ -7,33 +7,78 @@ var path = require("path")
   , Backbone = require('Backbone')
   , modelReaction = require('../lib/reactions/model')
 
+delete require.cache[require.resolve('Backbone')]
+var BackboneClone = require('Backbone') // To Test Bug. EndDash module might have a different Backbone then a client's
+                                        // main application. Internally we use !(model instanceof Backbone.Model || ... instanceof Backbone.Collection)
+                                        // this test is intended to check that our code now handles this case
 
-describe("When dealing with models that are not Backbone models but support the functionality we need", function(){
-  beforeEach(function(){
-    var backModel = new Backbone.Model()
-    this.supportedModel = function(){
-      this.name = "supportedModel"
-      this.get = function(key){return this.key}
-      this.set = function(key, value ){this.key = value}
-      this.on = function(){}
-      this.once = function(){}
-    }
-  })
-  it("Should not force my model to be a Backbone model", function(){
-    var model = new this.supportedModel()
-    var template = generateTemplate({user: model}, "<div class='user-'><div class='name-'></div></div>")
+describe("With a backbone model from a different backbone object", function(){
+  it("Should still work properly", function(){
+    var model = new BackboneClone.Model({persisted: "Chelsa Piers"})
+      , template = generateTemplate({user: model}, "<div class='user-'><div class='persisted-'></div></div>")
+
+    expect($('.persisted-').html()).to.be('Chelsa Piers')
+    model.set('persisted', 'Changed')
+    expect($('.persisted-').html()).to.be('Changed')
   })
 })
 
-describe("When dealing with models that are not Backbone models and do not support the functionality we need", function(){
+describe("With a backbone model", function(){
   beforeEach(function(){
     var backModel = new Backbone.Model()
-    this.unSupportedModel = function(){
-      this.name = "unsupportedModel"
-    }
   })
-  it("Should force my model to be a Backbone model", function(){
-    var model = new this.unSupportedModel()
-    var template = generateTemplate({user: model}, "<div class='user-'><div class='name-'></div></div>")
+  it("Should work as normal", function(){
+    var model = new Backbone.Model({persisted: "Chelsa Piers"})
+      , template = generateTemplate({user: model}, "<div class='user-'><div class='persisted-'></div></div>")
+
+    expect($('.persisted-').html()).to.be('Chelsa Piers')
+    model.set('persisted', 'Changed')
+    expect($('.persisted-').html()).to.be('Changed')
   })
+})
+
+describe("With a backbone collection from a different backbone object", function(){
+  beforeEach(function(){
+    this.collection = new BackboneClone.Collection()
+    this.templateString = "<div class='users-'><div class ='user-'><div class=' #{hook} persisted-'></div></div></div>"
+  })
+
+  describe("With models from a different backbone object", function(){
+    it("Should still work properly", function(){
+      var model1 = new BackboneClone.Model({persisted: "Chelsa Piers", hook: '1'})
+        , model2 = new BackboneClone.Model({persisted: "Columbus circle", hook: '2'})
+        , model3 = new BackboneClone.Model({persisted: "Soho", hook: '3'})
+      this.collection.add([model1, model2, model3])
+      var template = generateTemplate({users: this.collection}, this.templateString)
+      expect($('.1').html()).to.be(model1.get('persisted'))
+      expect($('.2').html()).to.be(model2.get('persisted'))
+      expect($('.3').html()).to.be(model3.get('persisted'))
+      model1.set('persisted', 'Changed1')
+      model2.set('persisted', 'Changed2')
+      model3.set('persisted', 'Changed3')
+      expect($('.1').html()).to.be(model1.get('persisted'))
+      expect($('.2').html()).to.be(model2.get('persisted'))
+      expect($('.3').html()).to.be(model3.get('persisted'))
+    })
+  })
+
+  describe("With anonymous models", function(){
+    it("Should still interpolate values but changes will not be updated", function(){
+      var model1 = {persisted: "Chelsa Piers", hook: '1'}
+        , model2 = {persisted: "Columbus circle", hook: '2'}
+        , model3 = {persisted: "Soho", hook: '3'}
+      this.collection.add([model1, model2, model3])
+      var template = generateTemplate({users: this.collection}, this.templateString)
+      expect($('.1').html()).to.be(model1.persisted)
+      expect($('.2').html()).to.be(model2.persisted)
+      expect($('.3').html()).to.be(model3.persisted)
+      model1.persisted = 'Changed1'
+      model2.persisted = 'Changed2'
+      model3.persisted = 'Changed3'
+      expect($('.1').html()).to.be("Chelsa Piers")
+      expect($('.2').html()).to.be("Columbus circle")
+      expect($('.3').html()).to.be("Soho")
+    })
+  })
+
 })

--- a/test/non_backbone_integration.js
+++ b/test/non_backbone_integration.js
@@ -10,41 +10,41 @@ delete require.cache[require.resolve('Backbone')];
 var BackboneClone = require('Backbone');// Internally we use !(model instanceof Backbone.Model || ... instanceof Backbone.Collection)
                                         // If the Backbone for EndDash is different then the clients, we want to handle this case.
                                         // See lib/reactions/model.js for fix.
-describe("With a set of models, collections, and a template", function(){
+describe("With a set of models, collections, and templates", function(){
   beforeEach(function(){
-    this.literalModel1 = {persisted: "Chelsa Piers", hook: '1'}
-    this.literalModel2 = {persisted: "Columbus circle", hook: '2'}
-    this.literalModel3 = {persisted: "Soho", hook: '3'};
-    this.cloneModel1 = new BackboneClone.Model({persisted: "Chelsa Piers", hook: '1'})
-    this.cloneModel2 = new BackboneClone.Model({persisted: "Columbus circle", hook: '2'})
-    this.cloneModel3 = new BackboneClone.Model({persisted: "Soho", hook: '3'});
-    this.backboneModel1 = new Backbone.Model({persisted: "Chelsa Piers", hook: '1'})
-    this.backboneModel2 = new Backbone.Model({persisted: "Columbus circle", hook: '2'})
-    this.backboneModel3 = new Backbone.Model({persisted: "Soho", hook: '3'});
+    this.literalModel1 = {persisted: "Chelsa Piers"};
+    this.literalModel2 = {persisted: "Columbus circle"};
+    this.literalModel3 = {persisted: "Soho"};
+    this.cloneModel1 = new BackboneClone.Model({persisted: "Chelsa Piers"});
+    this.cloneModel2 = new BackboneClone.Model({persisted: "Columbus circle"});
+    this.cloneModel3 = new BackboneClone.Model({persisted: "Soho"});
+    this.backboneModel1 = new Backbone.Model({persisted: "Chelsa Piers"});
+    this.backboneModel2 = new Backbone.Model({persisted: "Columbus circle"});
+    this.backboneModel3 = new Backbone.Model({persisted: "Soho"});
     this.modelHTMLTemplate = "<div class='user-'>" +
                                 "<div class='persisted-'>" +
                                 "</div>" +
                               "</div>";
     this.collectionHTMLTemplate = "<div class='users-'>" +
                                     "<div class ='user-'>" +
-                                      "<div class=' #{hook} persisted-'>" +
+                                      "<div class=' persisted-'>" +
                                       "</div>" +
                                     "</div>" +
                                   "</div>";
-  })
+  });
 
   describe("binding a backbone model from a different backbone object", function(){
     beforeEach(function(){
-      this.template = generateTemplate({user: this.cloneModel1}, this.modelHTMLTemplate)
-    })
+      this.template = generateTemplate({user: this.cloneModel1}, this.modelHTMLTemplate);
+    });
     it("should interpolate the model's attribute into the html", function(){
       expect($('.persisted-').html()).to.be('Chelsa Piers');
-    })
+    });
     it("should update the corrosponding attribute", function(){
       this.cloneModel1.set('persisted', 'Changed');
       expect($('.persisted-').html()).to.be('Changed');
-    })
-  })
+    });
+  });
 
   describe("With a backbone model", function(){
     it("binding it to a template should work normally", function(){
@@ -52,133 +52,131 @@ describe("With a set of models, collections, and a template", function(){
       expect($('.persisted-').html()).to.be('Chelsa Piers');
       this.backboneModel1.set('persisted', 'Changed');
       expect($('.persisted-').html()).to.be('Changed');
-    })
-  })
+    });
+  });
 
   describe("With a backbone collection from a different backbone object", function(){
     beforeEach(function(){
       this.collection = new BackboneClone.Collection();
-    })
+    });
     describe("With models from a different backbone object", function(){
       it("binding the collection and models to a template should work normally", function(){
         this.collection.add([this.cloneModel1, this.cloneModel2, this.cloneModel3]);
         var template = generateTemplate({users: this.collection}, this.collectionHTMLTemplate);
-        expect($('.1').html()).to.be(this.cloneModel1.get('persisted'));
-        expect($('.2').html()).to.be(this.cloneModel2.get('persisted'));
-        expect($('.3').html()).to.be(this.cloneModel3.get('persisted'));
+        expect($('.users- .user-:nth-child(1)').text()).to.be(this.cloneModel1.get('persisted'));
+        expect($('.users- .user-:nth-child(2)').text()).to.be(this.cloneModel2.get('persisted'));
+        expect($('.users- .user-:nth-child(3)').text()).to.be(this.cloneModel3.get('persisted'));
         this.cloneModel1.set('persisted', 'Changed1');
         this.cloneModel2.set('persisted', 'Changed2');
         this.cloneModel3.set('persisted', 'Changed3');
-        expect($('.1').html()).to.be(this.cloneModel1.get('persisted'));
-        expect($('.2').html()).to.be(this.cloneModel2.get('persisted'));
-        expect($('.3').html()).to.be(this.cloneModel3.get('persisted'));
-      })
-    })
+        expect($('.users- .user-:nth-child(1)').text()).to.be(this.cloneModel1.get('persisted'));
+        expect($('.users- .user-:nth-child(2)').text()).to.be(this.cloneModel2.get('persisted'));
+        expect($('.users- .user-:nth-child(3)').text()).to.be(this.cloneModel3.get('persisted'));
+      });
+    });
 
     describe("With anonymous models, binding the collection and models to a template ", function(){
       it("should interpolate values but not update on model changes", function(){
         this.collection.add([this.literalModel1, this.literalModel2, this.literalModel3]);
         var template = generateTemplate({users: this.collection}, this.collectionHTMLTemplate);
-        expect($('.1').html()).to.be(this.literalModel1.persisted);
-        expect($('.2').html()).to.be(this.literalModel2.persisted);
-        expect($('.3').html()).to.be(this.literalModel3.persisted);
+        expect($('.users- .user-:nth-child(1)').text()).to.be(this.literalModel1.persisted);
+        expect($('.users- .user-:nth-child(2)').text()).to.be(this.literalModel2.persisted);
+        expect($('.users- .user-:nth-child(3)').text()).to.be(this.literalModel3.persisted);
         this.literalModel1.persisted = 'Changed1';
         this.literalModel2.persisted = 'Changed2';
         this.literalModel3.persisted = 'Changed3';
-        expect($('.1').html()).to.be("Chelsa Piers");
-        expect($('.2').html()).to.be("Columbus circle");
-        expect($('.3').html()).to.be("Soho");
-      })
-    })
+        expect($('.users- .user-:nth-child(1)').text()).to.be("Chelsa Piers");
+        expect($('.users- .user-:nth-child(2)').text()).to.be("Columbus circle");
+        expect($('.users- .user-:nth-child(3)').text()).to.be("Soho");
+      });
+    });
 
     describe("With a mix of different model kinds", function(){
       it("binding them to a template should still work for each as expected", function(){
         this.collection.add([this.cloneModel1, this.literalModel2, this.backboneModel3]);
         var template = generateTemplate({users: this.collection}, this.collectionHTMLTemplate);
-        expect($('.1').html()).to.be(this.cloneModel1.get('persisted'));
-        expect($('.2').html()).to.be(this.literalModel2.persisted);
-        expect($('.3').html()).to.be(undefined);
+        expect($('.users- .user-:nth-child(1)').text()).to.be(this.cloneModel1.get('persisted'));
+        expect($('.users- .user-:nth-child(2)').text()).to.be(this.literalModel2.persisted);
+        expect($('.users- .user-:nth-child(3)').text()).to.be('');
         this.cloneModel1.set('persisted', 'Changed1');
         this.literalModel2.persisted = 'Changed2';
         this.backboneModel3.set('persisted', 'Changed3');
-        expect($('.1').html()).to.be(this.cloneModel1.get('persisted'));
-        expect($('.2').html()).to.be("Columbus circle");
-        expect($('.3').html()).to.be(undefined);
-      })
-    })
-  })
-
+        expect($('.users- .user-:nth-child(1)').text()).to.be(this.cloneModel1.get('persisted'));
+        expect($('.users- .user-:nth-child(2)').text()).to.be("Columbus circle");
+        expect($('.users- .user-:nth-child(3)').text()).to.be('');
+      });
+    });
+  });
 
   describe("With a backbone collection from the same backbone object", function(){
     beforeEach(function(){
       this.collection = new Backbone.Collection();
-    })
-
+    });
     describe("With models from a different backbone object", function(){
       it("Binding them to a template should not work properly", function(){
         this.collection.add([this.cloneModel1, this.cloneModel2, this.cloneModel3]);
         var template = generateTemplate({users: this.collection}, this.collectionHTMLTemplate);
-        expect($('.1').html()).to.be(undefined);
-        expect($('.2').html()).to.be(undefined);
-        expect($('.3').html()).to.be(undefined);
+        expect($('.users- .user-:nth-child(1)').text()).to.be('');
+        expect($('.users- .user-:nth-child(2)').text()).to.be('');
+        expect($('.users- .user-:nth-child(3)').text()).to.be('');
         this.cloneModel1.set('persisted', 'Changed1');
         this.cloneModel2.set('persisted', 'Changed2');
         this.cloneModel3.set('persisted', 'Changed3');
-        expect($('.1').html()).to.be(undefined);
-        expect($('.2').html()).to.be(undefined);
-        expect($('.3').html()).to.be(undefined);
-      })
-    })
+        expect($('.users- .user-:nth-child(1)').text()).to.be('');
+        expect($('.users- .user-:nth-child(2)').text()).to.be('');
+        expect($('.users- .user-:nth-child(3)').text()).to.be('');
+      });
+    });
 
     describe("With models from the same backbone object", function(){
       it("binding them to a template should work normally", function(){
         this.collection.add([this.backboneModel1, this.backboneModel2, this.backboneModel3]);
         var template = generateTemplate({users: this.collection}, this.collectionHTMLTemplate);
-        expect($('.1').html()).to.be(this.backboneModel1.get('persisted'));
-        expect($('.2').html()).to.be(this.backboneModel2.get('persisted'));
-        expect($('.3').html()).to.be(this.backboneModel3.get('persisted'));
+        expect($('.users- .user-:nth-child(1)').text()).to.be(this.backboneModel1.get('persisted'));
+        expect($('.users- .user-:nth-child(2)').text()).to.be(this.backboneModel2.get('persisted'));
+        expect($('.users- .user-:nth-child(3)').text()).to.be(this.backboneModel3.get('persisted'));
         this.backboneModel1.set('persisted', 'Changed1');
         this.backboneModel2.set('persisted', 'Changed2');
         this.backboneModel3.set('persisted', 'Changed3');
-        expect($('.1').html()).to.be(this.backboneModel1.get('persisted'));
-        expect($('.2').html()).to.be(this.backboneModel2.get('persisted'));
-        expect($('.3').html()).to.be(this.backboneModel3.get('persisted'));
-      })
-    })
+        expect($('.users- .user-:nth-child(1)').text()).to.be(this.backboneModel1.get('persisted'));
+        expect($('.users- .user-:nth-child(2)').text()).to.be(this.backboneModel2.get('persisted'));
+        expect($('.users- .user-:nth-child(3)').text()).to.be(this.backboneModel3.get('persisted'));
+      });
+    });
 
     describe("With anonymous models binding the collection/models to a template ", function(){
       it("should still interpolate values but changes will not be updated", function(){
         this.collection.add([this.literalModel1, this.literalModel2, this.literalModel3]);
         var template = generateTemplate({users: this.collection}, this.collectionHTMLTemplate);
-        expect($('.1').html()).to.be(this.literalModel1.persisted);
-        expect($('.2').html()).to.be(this.literalModel2.persisted);
-        expect($('.3').html()).to.be(this.literalModel3.persisted);
+        expect($('.users- .user-:nth-child(1)').text()).to.be(this.literalModel1.persisted);
+        expect($('.users- .user-:nth-child(2)').text()).to.be(this.literalModel2.persisted);
+        expect($('.users- .user-:nth-child(3)').text()).to.be(this.literalModel3.persisted);
         this.literalModel1.persisted = 'Changed1';
         this.literalModel2.persisted = 'Changed2';
         this.literalModel3.persisted = 'Changed3';
-        expect($('.1').html()).to.be("Chelsa Piers");
-        expect($('.2').html()).to.be("Columbus circle");
-        expect($('.3').html()).to.be("Soho");
-      })
-    })
+        expect($('.users- .user-:nth-child(1)').text()).to.be("Chelsa Piers");
+        expect($('.users- .user-:nth-child(2)').text()).to.be("Columbus circle");
+        expect($('.users- .user-:nth-child(3)').text()).to.be("Soho");
+      });
+    });
 
     describe("With a mix of different model kinds", function(){
       it("binding them to a template should still work for each type as expected", function(){
         this.collection.add([this.backboneModel1, this.literalModel2, this.cloneModel3]);
         var template = generateTemplate({users: this.collection}, this.collectionHTMLTemplate);
-        expect($('.1').html()).to.be(this.backboneModel1.get('persisted'));
-        expect($('.2').html()).to.be(this.literalModel2.persisted);
-        expect($('.3').html()).to.be(undefined);
+        expect($('.users- .user-:nth-child(1)').text()).to.be(this.backboneModel1.get('persisted'));
+        expect($('.users- .user-:nth-child(2)').text()).to.be(this.literalModel2.persisted);
+        expect($('.users- .user-:nth-child(3)').text()).to.be('');
         this.backboneModel1.set('persisted', 'Changed1');
         this.literalModel2.persisted = 'Changed2';
         this.cloneModel3.set('persisted', 'Changed3');
-        expect($('.1').html()).to.be(this.backboneModel1.get('persisted'));
-        expect($('.2').html()).to.be("Columbus circle");
-        expect($('.3').html()).to.be(undefined);
-      })
-    })
-  })
-})
+        expect($('.users- .user-:nth-child(1)').text()).to.be(this.backboneModel1.get('persisted'));
+        expect($('.users- .user-:nth-child(2)').text()).to.be("Columbus circle");
+        expect($('.users- .user-:nth-child(3)').text()).to.be('');
+      });
+    });
+  });
+});
 
 
 

--- a/test/non_backbone_integration.js
+++ b/test/non_backbone_integration.js
@@ -4,60 +4,60 @@ var path = require("path")
   , expect = require("expect.js")
   , fs = require("fs")
   , generateTemplate = require("./support/generate_template")
-  , Backbone = require('Backbone')
+  , Backbone = require('Backbone');
 
-delete require.cache[require.resolve('Backbone')]
-var BackboneClone = require('Backbone') // Internally we use !(model instanceof Backbone.Model || ... instanceof Backbone.Collection)
+delete require.cache[require.resolve('Backbone')];
+var BackboneClone = require('Backbone');// Internally we use !(model instanceof Backbone.Model || ... instanceof Backbone.Collection)
                                         // If the Backbone for EndDash is different then the clients, we want to handle this case.
                                         // See lib/reactions/model.js for fix.
 
 describe("With a backbone model from a different backbone object", function(){
   it("binding it to a template should work normally", function(){
     var model = new BackboneClone.Model({persisted: "Chelsa Piers"})
-      , template = generateTemplate({user: model}, "<div class='user-'><div class='persisted-'></div></div>")
+      , template = generateTemplate({user: model}, "<div class='user-'><div class='persisted-'></div></div>");
 
-    expect($('.persisted-').html()).to.be('Chelsa Piers')
-    model.set('persisted', 'Changed')
-    expect($('.persisted-').html()).to.be('Changed')
+    expect($('.persisted-').html()).to.be('Chelsa Piers');
+    model.set('persisted', 'Changed');
+    expect($('.persisted-').html()).to.be('Changed');
   })
 })
 
 describe("With a backbone model", function(){
   beforeEach(function(){
-    var backModel = new Backbone.Model()
+    var backModel = new Backbone.Model();
   })
   it("binding it to a template should work normally", function(){
     var model = new Backbone.Model({persisted: "Chelsa Piers"})
-      , template = generateTemplate({user: model}, "<div class='user-'><div class='persisted-'></div></div>")
+      , template = generateTemplate({user: model}, "<div class='user-'><div class='persisted-'></div></div>");
 
-    expect($('.persisted-').html()).to.be('Chelsa Piers')
-    model.set('persisted', 'Changed')
-    expect($('.persisted-').html()).to.be('Changed')
+    expect($('.persisted-').html()).to.be('Chelsa Piers');
+    model.set('persisted', 'Changed');
+    expect($('.persisted-').html()).to.be('Changed');
   })
 })
 
 describe("With a backbone collection from a different backbone object", function(){
   beforeEach(function(){
-    this.collection = new BackboneClone.Collection()
-    this.templateString = "<div class='users-'><div class ='user-'><div class=' #{hook} persisted-'></div></div></div>"
+    this.collection = new BackboneClone.Collection();
+    this.templateString = "<div class='users-'><div class ='user-'><div class=' #{hook} persisted-'></div></div></div>";
   })
 
   describe("With models from a different backbone object", function(){
     it("binding the collection and models to a template should work normally", function(){
       var model1 = new BackboneClone.Model({persisted: "Chelsa Piers", hook: '1'})
         , model2 = new BackboneClone.Model({persisted: "Columbus circle", hook: '2'})
-        , model3 = new BackboneClone.Model({persisted: "Soho", hook: '3'})
-      this.collection.add([model1, model2, model3])
-      var template = generateTemplate({users: this.collection}, this.templateString)
-      expect($('.1').html()).to.be(model1.get('persisted'))
-      expect($('.2').html()).to.be(model2.get('persisted'))
-      expect($('.3').html()).to.be(model3.get('persisted'))
-      model1.set('persisted', 'Changed1')
-      model2.set('persisted', 'Changed2')
-      model3.set('persisted', 'Changed3')
-      expect($('.1').html()).to.be(model1.get('persisted'))
-      expect($('.2').html()).to.be(model2.get('persisted'))
-      expect($('.3').html()).to.be(model3.get('persisted'))
+        , model3 = new BackboneClone.Model({persisted: "Soho", hook: '3'});
+      this.collection.add([model1, model2, model3]);
+      var template = generateTemplate({users: this.collection}, this.templateString);
+      expect($('.1').html()).to.be(model1.get('persisted'));
+      expect($('.2').html()).to.be(model2.get('persisted'));
+      expect($('.3').html()).to.be(model3.get('persisted'));
+      model1.set('persisted', 'Changed1');
+      model2.set('persisted', 'Changed2');
+      model3.set('persisted', 'Changed3');
+      expect($('.1').html()).to.be(model1.get('persisted'));
+      expect($('.2').html()).to.be(model2.get('persisted'));
+      expect($('.3').html()).to.be(model3.get('persisted'));
     })
   })
 
@@ -65,18 +65,18 @@ describe("With a backbone collection from a different backbone object", function
     it("should interpolate values but not update on model changes", function(){
       var model1 = {persisted: "Chelsa Piers", hook: '1'}
         , model2 = {persisted: "Columbus circle", hook: '2'}
-        , model3 = {persisted: "Soho", hook: '3'}
-      this.collection.add([model1, model2, model3])
-      var template = generateTemplate({users: this.collection}, this.templateString)
-      expect($('.1').html()).to.be(model1.persisted)
-      expect($('.2').html()).to.be(model2.persisted)
-      expect($('.3').html()).to.be(model3.persisted)
-      model1.persisted = 'Changed1'
-      model2.persisted = 'Changed2'
-      model3.persisted = 'Changed3'
-      expect($('.1').html()).to.be("Chelsa Piers")
-      expect($('.2').html()).to.be("Columbus circle")
-      expect($('.3').html()).to.be("Soho")
+        , model3 = {persisted: "Soho", hook: '3'};
+      this.collection.add([model1, model2, model3]);
+      var template = generateTemplate({users: this.collection}, this.templateString);
+      expect($('.1').html()).to.be(model1.persisted);
+      expect($('.2').html()).to.be(model2.persisted);
+      expect($('.3').html()).to.be(model3.persisted);
+      model1.persisted = 'Changed1';
+      model2.persisted = 'Changed2';
+      model3.persisted = 'Changed3';
+      expect($('.1').html()).to.be("Chelsa Piers");
+      expect($('.2').html()).to.be("Columbus circle");
+      expect($('.3').html()).to.be("Soho");
     })
   })
 
@@ -84,44 +84,49 @@ describe("With a backbone collection from a different backbone object", function
     it("binding them to a template should still work for each as expected", function(){
       var model1 = new BackboneClone.Model({persisted: "Chelsa Piers", hook: '1'})
         , model2 = {persisted: "Columbus circle", hook: '2'}
-        , model3 = new Backbone.Model({persisted: "Soho", hook: '3'})
-      this.collection.add([model1, model2, model3])
-      var template = generateTemplate({users: this.collection}, this.templateString)
-      expect($('.1').html()).to.be(model1.get('persisted'))
-      expect($('.2').html()).to.be(model2.persisted)
-      expect($('.3').html()).to.be(undefined)
-      model1.set('persisted', 'Changed1')
-      model2.persisted = 'Changed2'
-      model3.set('persisted', 'Changed3')
-      expect($('.1').html()).to.be(model1.get('persisted'))
-      expect($('.2').html()).to.be("Columbus circle")
-      expect($('.3').html()).to.be(undefined)
+        , model3 = new Backbone.Model({persisted: "Soho", hook: '3'});
+      this.collection.add([model1, model2, model3]);
+      var template = generateTemplate({users: this.collection}, this.templateString);
+      expect($('.1').html()).to.be(model1.get('persisted'));
+      expect($('.2').html()).to.be(model2.persisted);
+      expect($('.3').html()).to.be(undefined);
+      model1.set('persisted', 'Changed1');
+      model2.persisted = 'Changed2';
+      model3.set('persisted', 'Changed3');
+      expect($('.1').html()).to.be(model1.get('persisted'));
+      expect($('.2').html()).to.be("Columbus circle");
+      expect($('.3').html()).to.be(undefined);
     })
   })
 })
 
 describe("With a backbone collection from the same backbone object", function(){
   beforeEach(function(){
-    this.collection = new Backbone.Collection()
-    this.templateString = "<div class='users-'><div class ='user-'><div class=' #{hook} persisted-'></div></div></div>"
+    this.collection = new Backbone.Collection();
+    this.templateString = "<div class='users-'>" +
+                            "<div class ='user-'>" +
+                              "<div class=' #{hook} persisted-'>" +
+                              "</div>" +
+                            "</div>" +
+                          "</div>";
   })
 
   describe("With models from a different backbone object", function(){
     it("Binding them to a template should not work properly", function(){
       var model1 = new BackboneClone.Model({persisted: "Chelsa Piers", hook: '1'})
         , model2 = new BackboneClone.Model({persisted: "Columbus circle", hook: '2'})
-        , model3 = new BackboneClone.Model({persisted: "Soho", hook: '3'})
-      this.collection.add([model1, model2, model3])
-      var template = generateTemplate({users: this.collection}, this.templateString)
-      expect($('.1').html()).to.be(undefined)
-      expect($('.2').html()).to.be(undefined)
-      expect($('.3').html()).to.be(undefined)
-      model1.set('persisted', 'Changed1')
-      model2.set('persisted', 'Changed2')
-      model3.set('persisted', 'Changed3')
-      expect($('.1').html()).to.be(undefined)
-      expect($('.2').html()).to.be(undefined)
-      expect($('.3').html()).to.be(undefined)
+        , model3 = new BackboneClone.Model({persisted: "Soho", hook: '3'});
+      this.collection.add([model1, model2, model3]);
+      var template = generateTemplate({users: this.collection}, this.templateString);
+      expect($('.1').html()).to.be(undefined);
+      expect($('.2').html()).to.be(undefined);
+      expect($('.3').html()).to.be(undefined);
+      model1.set('persisted', 'Changed1');
+      model2.set('persisted', 'Changed2');
+      model3.set('persisted', 'Changed3');
+      expect($('.1').html()).to.be(undefined);
+      expect($('.2').html()).to.be(undefined);
+      expect($('.3').html()).to.be(undefined);
     })
   })
 
@@ -129,18 +134,18 @@ describe("With a backbone collection from the same backbone object", function(){
     it("binding them to a template should work normally", function(){
       var model1 = new Backbone.Model({persisted: "Chelsa Piers", hook: '1'})
         , model2 = new Backbone.Model({persisted: "Columbus circle", hook: '2'})
-        , model3 = new Backbone.Model({persisted: "Soho", hook: '3'})
-      this.collection.add([model1, model2, model3])
-      var template = generateTemplate({users: this.collection}, this.templateString)
-      expect($('.1').html()).to.be(model1.get('persisted'))
-      expect($('.2').html()).to.be(model2.get('persisted'))
-      expect($('.3').html()).to.be(model3.get('persisted'))
-      model1.set('persisted', 'Changed1')
-      model2.set('persisted', 'Changed2')
-      model3.set('persisted', 'Changed3')
-      expect($('.1').html()).to.be(model1.get('persisted'))
-      expect($('.2').html()).to.be(model2.get('persisted'))
-      expect($('.3').html()).to.be(model3.get('persisted'))
+        , model3 = new Backbone.Model({persisted: "Soho", hook: '3'});
+      this.collection.add([model1, model2, model3]);
+      var template = generateTemplate({users: this.collection}, this.templateString);
+      expect($('.1').html()).to.be(model1.get('persisted'));
+      expect($('.2').html()).to.be(model2.get('persisted'));
+      expect($('.3').html()).to.be(model3.get('persisted'));
+      model1.set('persisted', 'Changed1');
+      model2.set('persisted', 'Changed2');
+      model3.set('persisted', 'Changed3');
+      expect($('.1').html()).to.be(model1.get('persisted'));
+      expect($('.2').html()).to.be(model2.get('persisted'));
+      expect($('.3').html()).to.be(model3.get('persisted'));
     })
   })
 
@@ -148,18 +153,18 @@ describe("With a backbone collection from the same backbone object", function(){
     it("should still interpolate values but changes will not be updated", function(){
       var model1 = {persisted: "Chelsa Piers", hook: '1'}
         , model2 = {persisted: "Columbus circle", hook: '2'}
-        , model3 = {persisted: "Soho", hook: '3'}
-      this.collection.add([model1, model2, model3])
-      var template = generateTemplate({users: this.collection}, this.templateString)
-      expect($('.1').html()).to.be(model1.persisted)
-      expect($('.2').html()).to.be(model2.persisted)
-      expect($('.3').html()).to.be(model3.persisted)
-      model1.persisted = 'Changed1'
-      model2.persisted = 'Changed2'
-      model3.persisted = 'Changed3'
-      expect($('.1').html()).to.be("Chelsa Piers")
-      expect($('.2').html()).to.be("Columbus circle")
-      expect($('.3').html()).to.be("Soho")
+        , model3 = {persisted: "Soho", hook: '3'};
+      this.collection.add([model1, model2, model3]);
+      var template = generateTemplate({users: this.collection}, this.templateString);
+      expect($('.1').html()).to.be(model1.persisted);
+      expect($('.2').html()).to.be(model2.persisted);
+      expect($('.3').html()).to.be(model3.persisted);
+      model1.persisted = 'Changed1';
+      model2.persisted = 'Changed2';
+      model3.persisted = 'Changed3';
+      expect($('.1').html()).to.be("Chelsa Piers");
+      expect($('.2').html()).to.be("Columbus circle");
+      expect($('.3').html()).to.be("Soho");
     })
   })
 
@@ -167,18 +172,18 @@ describe("With a backbone collection from the same backbone object", function(){
     it("binding them to a template should still work for each type as expected", function(){
       var model1 = new Backbone.Model({persisted: "Chelsa Piers", hook: '1'})
         , model2 = {persisted: "Columbus circle", hook: '2'}
-        , model3 = new BackboneClone.Model({persisted: "Soho", hook: '3'})
-      this.collection.add([model1, model2, model3])
-      var template = generateTemplate({users: this.collection}, this.templateString)
-      expect($('.1').html()).to.be(model1.get('persisted'))
-      expect($('.2').html()).to.be(model2.persisted)
-      expect($('.3').html()).to.be(undefined)
-      model1.set('persisted', 'Changed1')
-      model2.persisted = 'Changed2'
-      model3.set('persisted', 'Changed3')
-      expect($('.1').html()).to.be(model1.get('persisted'))
-      expect($('.2').html()).to.be("Columbus circle")
-      expect($('.3').html()).to.be(undefined)
+        , model3 = new BackboneClone.Model({persisted: "Soho", hook: '3'});
+      this.collection.add([model1, model2, model3]);
+      var template = generateTemplate({users: this.collection}, this.templateString);
+      expect($('.1').html()).to.be(model1.get('persisted'));
+      expect($('.2').html()).to.be(model2.persisted);
+      expect($('.3').html()).to.be(undefined);
+      model1.set('persisted', 'Changed1');
+      model2.persisted = 'Changed2';
+      model3.set('persisted', 'Changed3');
+      expect($('.1').html()).to.be(model1.get('persisted'));
+      expect($('.2').html()).to.be("Columbus circle");
+      expect($('.3').html()).to.be(undefined);
     })
   })
 })


### PR DESCRIPTION
@yaymukund cc @tobowers 

This is a fix for when the Backbone EndDash uses is different then the Backbone that the client's app uses.

Ie., EndDash's Backbone === Client's Backbone // returns false

I ran into this with my node application which was a hella of a pain to track down but was rewarding once I did!

An important note is, though I do not think this will ever come up, adding a backbone model to a collection from a different backbone will not work properly (this is spec-ed). 

===== Below is fun random fact ==== no need to read ==== repeat fun & AWESOME but not necessary
(More details on last sentence). Backbone collections do ~ if not Backbone.Model || Collection convert it to use Backbone style events (so collections can listen for changes). That means take all top level attributes -> attribute object and do ModelPassedIn.attributes = attributes. With a BackboneModel from a different Backbone this overwrites its attributes with a nested version of itself. In conclusion. Collection.get(model).attributes.attributes is actually the model's attributes. Fun times and likely unncessary.
