### PR TITLE
End dash beta

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -1,6 +1,8 @@
 module.exports = function(grunt) {
   grunt.loadNpmTasks('grunt-contrib-watch');
+  grunt.loadNpmTasks('grunt-contrib-uglify');
   grunt.loadNpmTasks('grunt-simple-mocha');
+  grunt.loadNpmTasks('grunt-browserify');
 
   grunt.initConfig({
     simplemocha: {
@@ -10,16 +12,30 @@ module.exports = function(grunt) {
         reporter: 'spec'
       },
 
-      all: {src: ['test/**/*.js', '!test/support/**/*.js']}
+      dist: {src: ['test/**/*.js', '!test/support/**/*.js']}
     },
 
     watch: {
-      all: {
+      dist: {
         files: ['test/**/*.js'],
         tasks: ['simplemocha']
+      }
+    },
+
+    browserify: {
+      dist: {
+        files: {'build/end-dash.js': ['lib/end-dash.js']}
+      }
+    },
+
+    uglify: {
+      dist: {
+        files: {'build/end-dash.min.js': ['build/enddash.js']}
       }
     }
   });
 
-  grunt.registerTask('default', ['simplemocha']);
+  grunt.registerTask('default', ['build']);
+  grunt.registerTask('build', ['browserify', 'uglify']);
+  grunt.registerTask('test', ['simplemocha']);
 };

--- a/README.md
+++ b/README.md
@@ -1,104 +1,63 @@
-  End Dash is a client side templating language, you write templates in semantic HTML.
+End Dash is a bindings-aware client-side templating language built on top of valid HTML.
 
-Getting started
-===============
+## Getting started
+
+Include the library and dependencies:
+```html
+<script src="//ajax.googleapis.com/ajax/libs/jquery/1.10.2/jquery.min.js"></script>
+<script src="http://underscorejs.org/underscore.js"></script>
+<script src="http://backbonejs.org/backbone.js"></script>
+<script src="/scripts/end-dash.js"></script>
+```
+
+Define your templates:
+```html
+<script type="text/enddash" name="user">
+  <div class="user">
+    <p>
+      Hello, my name is <span class="firstName-"></span>
+      <span class="lastName-"></span>! I have something to tell you...
+    </p>
+
+    <strong class="catchphrase-"></strong>
+  </div>
+</script>
+```
+
+Bind templates to models in your application code:
+```javascript
+$.ready(function() {
+  // Load all the templates on the page.
+  EndDash.bootstrap();
+
+  var michael = new Backbone.Model({
+    firstName: 'Michael',
+    lastName: 'Jackson',
+    catchphrase: "You've been hit and struck by a smooth criminal!"
+  });
+
+  var template = EndDash.getTemplate('user', michael);
+
+  $('#content').html(template.el);
+});
+```
+
+If your model changes, the DOM updates!
+
+## Building and testing
 
 ```bash
 npm install
 
-# if you don't have grunt
+# We use grunt for running tasks.
 npm install -g grunt-cli
 
+# Build end-dash in build/ directory
+grunt build # also aliased as `grunt`
+
 # Run tests
-grunt simplemocha
+grunt test
 
-# If you don't want grunt
-mocha test
-
-# To run tests and watch for changes:
+# Watch for changes and run tests
 grunt watch
 ```
-
-Or, as a bower component,
-
-```bash
-bower install
-```
-
-Example
-=======
-
-Here's an example of a typical end-dash template:
-
-```html
-<div class="message">
-Hey <a class="name-" href="/users/{user_id}"></a>,
-Here are some things to try in end dash:
-<ul class="things-">
-  <li class="thing-">
-    <div class="title-"></div>
-    <div class="description-"></div>
-  </li>
-</ul>
-```
-
-Collections
-===========
-
-Defining Collections in end-dash is really easy.  
-  * Step One: Make a container with the plural name of your objects as class name
-  * Step Two: Inside the previous container, make another element with the singular of your object as the class name
-  * Step Three: Add dashes to the classes
-
-example
--------
-
-```html
-<ul class="things-">
-  <li class="thing-">
-    <div class="title-"></div>
-    <div class="description-"></div>
-  </li>
-</ul>
-```
-
-This is a collection of things.  Each thing has a title and a description. 
-
-ideas
-=====
-
-  * This is only partially end-dash related, but we could do the template thing
-implicitly in the router, i.e. given the router classname and method, we
-get the correct template, and render it.  Unless you explicity declare what template
-you want.
-
-```coffeescript
-class SocialMail extends BaseRouter
-  "users/:userId/social_mail":"show"
-
-  @before ->
-    @currentUser = session.get("currentUser")
-
-  show: (userId)->
-    @socialMailConfiguration = SocialMailConfiguration.findBy { user: currentUser }
-    @mailingExplanation = new MailingExplanation.findBy { initiative: session.get("currentInitiative") }
-```
-
-behind the scenes this would basically do. 
-
-```coffeescript
-Template = EndDash.getTemplate("/new/templates/social_mails/show") 
-
-@template = new Template 
-  currentUser: session.get("currentUser"), 
-  socialMailConfiguration: SocialMailConfiguration.findBy { user: currentUser }
-  etc: etc
-
-#and then when another route is loaded...
-
-@template.unbindAllEvents()
-```
-Boom, cleanup for free
-
-  * We could also do the "layouts" thing.  i.e. we have a layout that gets autorendered
-and then we render your template inside of that.

--- a/examples/models.html
+++ b/examples/models.html
@@ -1,0 +1,48 @@
+<!doctype html>
+
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+
+  <title>The King of Pop</title>
+  <meta name="description" content="A quick EndDash example.">
+  <meta name="author" content="Amicus">
+</head>
+
+<body>
+  <script src="http://ajax.googleapis.com/ajax/libs/jquery/1.10.2/jquery.min.js"></script>
+  <script src="http://underscorejs.org/underscore.js"></script>
+  <script src="http://backbonejs.org/backbone.js"></script>
+  <script src="../build/end-dash.js"></script>
+
+  <div id="content"></div>
+
+  <script type="text/enddash" name="user">
+    <div class="user">
+      <p>
+        Hello, my name is <span class="firstName-"></span>
+        <span class="lastName-"></span>! I have something to tell you...
+      </p>
+
+      <strong class="catchphrase-"></strong>
+    </div>
+  </script>
+
+  <script type="text/javascript">
+    $(function() {
+      // Load all the templates on the page.
+      EndDash.bootstrap();
+
+      var michael = new Backbone.Model({
+        firstName: 'Michael',
+        lastName: 'Jackson',
+        catchphrase: "You've been hit and struck by a smooth criminal!"
+      });
+
+      var template = EndDash.getTemplate('user', michael);
+
+      $('#content').html(template.el);
+    });
+  </script>
+</body>
+</html>

--- a/lib/end-dash.js
+++ b/lib/end-dash.js
@@ -20,7 +20,7 @@ _.each(reactions, Parser.registerReaction);
 
 module.exports = EndDash = {};
 
-EndDash.loadTemplatesFromPage = PageHelper.loadFromPage;
+EndDash.bootstrap = PageHelper.loadFromPage;
 EndDash.registerTemplate = TemplateStore.load;
 EndDash.getTemplateClass = TemplateStore.getTemplateClass;
 EndDash.registerView = ViewStore.load;

--- a/package.json
+++ b/package.json
@@ -22,6 +22,9 @@
     "awesome-docs": "git+ssh://git@github.com/Amicus/awesome-docs.git",
     "grunt": "~0.4.1",
     "grunt-simple-mocha": "~0.4.0",
-    "grunt-contrib-watch": "~0.5.3"
+    "grunt-contrib-watch": "~0.5.3",
+    "browserify": "~2.35.0",
+    "grunt-browserify": "~1.2.9",
+    "grunt-contrib-uglify": "~0.2.4"
   }
 }

--- a/test/end-dash.js
+++ b/test/end-dash.js
@@ -53,12 +53,12 @@ describe('EndDash', function(){
     });
   });
 
-  describe('loadTemplatesFromPage', function() {
+  describe('bootstrap', function() {
     describe('when loaded correctly', function() {
       before(function() {
         var fs = require('fs');
         window.document.body.innerHTML = fs.readFileSync(__dirname+'/support/templates/script_tags.js.ed');
-        EndDash.loadTemplatesFromPage();
+        EndDash.bootstrap();
       });
 
       it('loads templates from script tags', function() {
@@ -94,7 +94,7 @@ describe('EndDash', function(){
       });
 
       it('errors if a name isn\'t provided', function() {
-        expect(EndDash.loadTemplatesFromPage).to.throwError(/must have a 'name' attribute/);
+        expect(EndDash.bootstrap).to.throwError(/must have a 'name' attribute/);
       });
     });
   });


### PR DESCRIPTION
@bglusman 
cc @devmanhinton

This branch does a couple things:
- Adds grunt tasks for `build`, `uglify`
- Changes `loadTemplatesFromPage` to `bootstrap`
- Adds "Getting Started" documentation in the `README.md`
- Adds an `examples/` directory with a simple example.

We still need to document all the features. I think the in-depth docs can go in [the GitHub wiki for the project](https://github.com/Amicus/end-dash/wiki).
