### PR TITLE
The TemplateStore uses prototypal inheritance, is no longer singleton.

### DIFF
--- a/lib/compile.js
+++ b/lib/compile.js
@@ -1,9 +1,8 @@
 // We're just keeping this around because base-backbone expects it to be here.
 // In the long run, we should probably not expose lib/compile.
-var TemplateStore = require('./template_store'),
-    EndDash = require('./end-dash'),
+var EndDash = require('./end-dash'),
     _ = require('underscore');
 
 var Compiler = EndDash.compile;
-Compiler.registerTemplate = TemplateStore.load;
+Compiler.registerTemplate = EndDash.templateStore.load;
 module.exports = Compiler;

--- a/lib/end-dash.js
+++ b/lib/end-dash.js
@@ -1,8 +1,9 @@
 var _ = require('underscore'),
     Parser = require('./parser'),
     TemplateStore = require('./template_store'),
-    ViewStore = require('./view_store'),
+    templateStore = new TemplateStore(),
     PageHelper = require('./page_helper'),
+    ViewStore = require('./view_store'),
     reactions = [
       // The load order matters here...
       require('./reactions/partial'),
@@ -18,26 +19,29 @@ var _ = require('underscore'),
 
 _.each(reactions, Parser.registerReaction);
 
-module.exports = EndDash = {};
+exports.templateStore = templateStore;
 
-EndDash.bootstrap = PageHelper.loadFromPage;
-EndDash.registerTemplate = TemplateStore.load;
-EndDash.getTemplateClass = TemplateStore.getTemplateClass;
-EndDash.registerView = ViewStore.load;
+exports.bootstrap = PageHelper.loadFromPage;
 
-EndDash.getTemplate = function(templatePath, model) {
+exports.registerTemplate = _.bind(templateStore.load, templateStore);
+
+exports.getTemplateClass = _.bind(templateStore.getTemplateClass, templateStore);
+
+exports.registerView = ViewStore.load;
+
+exports.getTemplate = function(templatePath, model) {
   var Template = this.getTemplateClass(templatePath);
   return new Template(model);
-}
+};
 
-// This is a hack to make requiring a file that ends in .js.ed to return a
-// EndDash compiled version of that file. We need to expose it publicly,
-// because we have code that relies on it, but it's deprecated and not
-// officially a part of the public API.
-EndDash.compile = function(module, filename) {
+exports.compile = function(module, filename) {
+  // This is a hack to make requiring a file that ends in .js.ed to return a
+  // EndDash compiled version of that file. We need to expose it publicly,
+  // because we have code that relies on it, but it's deprecated and not
+  // officially a part of the public API.
   var fs = require('fs'),
       markup = fs.readFileSync(filename, 'utf8'),
       templateName = filename.replace(/\.js\.ed(\.erb)?$/, '');
 
-  module.exports = TemplateStore.loadAndParse(templateName, markup);
+  module.exports = templateStore.loadAndParse(templateName, markup);
 };

--- a/lib/page_helper.js
+++ b/lib/page_helper.js
@@ -1,5 +1,5 @@
-var _ = require('underscore')
-  , templateStore = require('./template_store');
+var _ = require('underscore'),
+    EndDash = require('./end-dash');
 
 // Only load HTML do not parse until template is requested
 // If this is changed be aware, order matters. If templates with
@@ -15,6 +15,6 @@ exports.loadFromPage = function () {
       throw new Error("Script tags of type text/enddash must have a 'name' attribute");
     }
 
-    templateStore.load($el.attr('name'), markup);
+    EndDash.templateStore.load($el.attr('name'), markup);
   });
 };

--- a/lib/reactions/collection.js
+++ b/lib/reactions/collection.js
@@ -1,10 +1,10 @@
 var Parser = require("../parser")
-  , TemplateStore = require('../template_store')
+  , EndDash = require('../end-dash')
   , Reaction = require("../reaction")
   , inflection = require("inflection")
   , _ = require("underscore")
   , get = require("../util").get
-  , rules = require("../rules")
+  , rules = require("../rules");
 
 var CollectionReaction = Reaction.extend({
 
@@ -117,7 +117,7 @@ var CollectionReaction = Reaction.extend({
       var child = $(element)
         , whenValue = rules.polymorphicValue(child)
         , templatePath = _.last(state.pathStack)
-        , Template = TemplateStore.loadAndParse(templatePath+whenValue, child);
+        , Template = EndDash.templateStore.loadAndParse(templatePath+whenValue, child);
 
       templates[whenValue] = Template;
       child.remove()

--- a/lib/template_store.js
+++ b/lib/template_store.js
@@ -2,66 +2,62 @@
 // and then returning template objects (lazily).
 var _ = require('underscore'),
     path = require('path'),
-    Parser = require('./parser'),
-    TemplateStore = {},
-    RAW_TEMPLATES = {},
-    TEMPLATES = {};
+    Parser = require('./parser');
 
 var pathToName = function(templatePath) {
   return path.normalize(templatePath);
 };
 
-var _parseTemplate = function(templatePath) {
+function TemplateStore() {
+  this.RAW_TEMPLATES = {};
+  this.TEMPLATES = {};
+};
+
+TemplateStore.prototype._parseTemplate = function(templatePath) {
   var name = pathToName(templatePath);
 
-  if (!TemplateStore.isLoaded(name)) {
+  if (!this.isLoaded(name)) {
     throw new Error('Could not find template: '+name);
   }
 
-  var markup = RAW_TEMPLATES[name];
+  var markup = this.RAW_TEMPLATES[name];
 
   return (new Parser(markup, {
     templateName: name,
-    templates: RAW_TEMPLATES
+    templates: this.RAW_TEMPLATES
   })).generate();
 };
 
-TemplateStore.isLoaded = function(templatePath) {
-  return !!RAW_TEMPLATES[templatePath];
+TemplateStore.prototype.isLoaded = function(templatePath) {
+  return !!this.RAW_TEMPLATES[templatePath];
 };
 
-TemplateStore.isParsed = function(templatePath) {
-  return !!TEMPLATES[templatePath];
+TemplateStore.prototype.isParsed = function(templatePath) {
+  return !!this.TEMPLATES[templatePath];
 };
 
-TemplateStore.load = function(templatePath, markup) {
+TemplateStore.prototype.load = function(templatePath, markup) {
   var name = pathToName(templatePath);
 
-  RAW_TEMPLATES[name] = markup;
+  this.RAW_TEMPLATES[name] = markup;
 
   if (this.isParsed(name)) {
-    delete TEMPLATES[name];
+    delete this.TEMPLATES[name];
   }
 };
 
-TemplateStore.loadAndParse = function(templatePath, markup) {
+TemplateStore.prototype.loadAndParse = function(templatePath, markup) {
   this.load(templatePath, markup);
   return this.getTemplateClass(templatePath);
 };
 
-TemplateStore.getTemplateClass = function(templatePath) {
+TemplateStore.prototype.getTemplateClass = function(templatePath) {
   var name = pathToName(templatePath);
 
   if (!this.isParsed(name)) {
-    TEMPLATES[name] = _parseTemplate(name);
+    this.TEMPLATES[name] = this._parseTemplate(name);
   }
-  return TEMPLATES[name];
+  return this.TEMPLATES[name];
 };
-
-_.bindAll(TemplateStore, 'isLoaded',
-                         'isParsed',
-                         'load',
-                         'loadAndParse',
-                         'getTemplateClass');
 
 module.exports = TemplateStore;

--- a/test/end-dash.js
+++ b/test/end-dash.js
@@ -3,7 +3,7 @@ require('./support/helper');
 var expect = require('expect.js'),
     Backbone = require('backbone'),
     EndDash = require('../lib/end-dash'),
-    TemplateStore = require('../lib/template_store'),
+    templateStore = EndDash.templateStore,
     ViewStore = require('../lib/view_store'),
     Template = require('../lib/template'),
     _ = require('underscore');
@@ -12,7 +12,7 @@ describe('EndDash', function(){
   describe('.registerTemplate', function() {
     it('loads templates to the store', function(){
       EndDash.registerTemplate('partials', '<div></div>');
-      expect(TemplateStore.isLoaded('partials')).to.be(true);
+      expect(templateStore.isLoaded('partials')).to.be(true);
     });
   });
 
@@ -62,11 +62,11 @@ describe('EndDash', function(){
       });
 
       it('loads templates from script tags', function() {
-        expect(TemplateStore.isLoaded('crow')).to.be(true);
+        expect(templateStore.isLoaded('crow')).to.be(true);
       });
 
       it('does not load non-EndDash script tags', function() {
-        expect(TemplateStore.isLoaded('non-end-dash')).to.be(false);
+        expect(templateStore.isLoaded('non-end-dash')).to.be(false);
       });
 
       describe('when retrieved with getTemplate', function() {

--- a/test/partials.js
+++ b/test/partials.js
@@ -7,7 +7,6 @@ var path = require("path")
   , _ = require("underscore")
   , jqts = require("../lib/util").jqts
   , EndDash = require("../lib/end-dash")
-  , TemplateStore = require('../lib/template_store')
   , generateTemplate = require("./support/generate_template")
 
 describe("A template with partials", function() {
@@ -24,7 +23,7 @@ describe("A template with partials", function() {
     }
 
     _(templates).each(function(template) {
-      TemplateStore.load(template, fs.readFileSync(__dirname + template).toString())
+      EndDash.templateStore.load(template, fs.readFileSync(__dirname + template).toString())
     })
 
     var template = generateTemplate(model, '/support/templates/partials.html')

--- a/test/support/generate_template.js
+++ b/test/support/generate_template.js
@@ -1,9 +1,8 @@
 var EndDash = require('../../lib/end-dash'),
-    TemplateStore = require('../../lib/template_store'),
     PageHelper = require('../../lib/page_helper'),
     testTemplateCount = 0;
 
-  require('./helper');
+require('./helper');
 
 module.exports = function(model, markupOrPath) {
   var Template, templatePath;

--- a/test/template_store.js
+++ b/test/template_store.js
@@ -1,18 +1,20 @@
 require('./support/helper');
 
 var expect = require("expect.js"),
+    _ = require('underscore'),
     Parser = require('../lib/parser'),
     Template = require('../lib/template'),
     TemplateStore = require('../lib/template_store'),
+    templateStore = new TemplateStore(),
 
     // easier to read..
-    isLoaded = TemplateStore.isLoaded,
-    isParsed = TemplateStore.isParsed,
-    load = TemplateStore.load,
-    loadAndParse = TemplateStore.loadAndParse,
-    getTemplateClass = TemplateStore.getTemplateClass;
+    isLoaded = _.bind(templateStore.isLoaded, templateStore),
+    isParsed = _.bind(templateStore.isParsed, templateStore),
+    load = _.bind(templateStore.load, templateStore),
+    loadAndParse = _.bind(templateStore.loadAndParse, templateStore),
+    getTemplateClass = _.bind(templateStore.getTemplateClass, templateStore);
 
-describe('TemplateStore', function() {
+describe('templateStore', function() {
   describe('.load', function() {
     it('loads markup without parsing', function() {
       load('user', '<div id="user"></div>');


### PR DESCRIPTION
@bglusman, @devmanhinton 

This branch makes it so we use prototypal inheritance and create `templateStore` instances (v. having a singleton `TemplateStore`).

``` js
// Before:
exports.create = function() {
  return {
    getTemplate: function() {...},
    isLoaded: function() {...},
    TEMPLATES: {},
    // etc.
  }
};

// After:
function TemplateStore() {
  this.TEMPLATES = {};
  this.RAW_TEMPLATES = {};
}

TemplateStore.prototype.isLoaded = function() {
  // can use this.TEMPLATES and this.RAW_TEMPLATES
}
```
