### PR TITLE
needed for global reference in examples

### DIFF
--- a/lib/end-dash.js
+++ b/lib/end-dash.js
@@ -53,4 +53,6 @@ var reactions = [
 
 _.each(reactions, Parser.registerReaction);
 
+EndDash = module.exports
+
 


### PR DESCRIPTION
@yaymukund this is needed for your examples directory to work after the template/view store changes eliminated EndDash variable in enddash.js file.
