### PR TITLE
inflectio needs to be in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,8 @@
   },
   "dependencies": {
     "underscore": "1.x.x",
-    "backbone": "x.x.x"
+    "backbone": "x.x.x",
+    "inflection": "x.x.x"
   },
   "engines": {
     "node": ">=0.6.0"


### PR DESCRIPTION
@bglusman We need inflection to support deprecation. 

Merging these two branches we must have accidentally removed it from the package.json.
