### PR TITLE
Fix margins on footer + nav & main content

### DIFF
--- a/Static Page/css/style.css
+++ b/Static Page/css/style.css
@@ -14,6 +14,8 @@ nav{
     width: 15%;
     background:white;
     position:fixed;
+    padding-left: 30px;
+    height: 100%;
 }
 
 nav .logoWrapper {
@@ -96,7 +98,7 @@ nav ul li a:hover{
 
 article{
   margin:10px;
-  padding:1em;
+  padding:3em;
 }
 
 article h1{
@@ -128,6 +130,7 @@ footer{
     width: 100%;
     height:200px;
     float: left;
+    margin-left: 3em;
 }
 
 footer h1{


### PR DESCRIPTION
@adelbalso @FredericoAndrade 

This fixes a bit of style that was off. Basically, the nav menu items were flush against the left side of the page. To the extent that the start of the word looked like it was being cut off. 

This fixes that and fix a few other styles to make everything consistent. 
