### PR TITLE
Made getting started much clearer

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,8 +9,6 @@ Please [see the dependency section](#dependencies) for further details.
 
 [Getting started](#getting-started)
 
-[Templating from models](#templating-from-models)
-
 [Building and testing](#building-and-testing)
 
 [Play with examples](#play-with-examples)
@@ -20,7 +18,7 @@ Please [see the dependency section](#dependencies) for further details.
 
 ## Getting started
 
-Include the library and dependencies:
+Include the library and dependencies.
 
 ```html
 <script src="//ajax.googleapis.com/ajax/libs/jquery/1.10.2/jquery.min.js"></script>
@@ -29,9 +27,7 @@ Include the library and dependencies:
 <script src="/scripts/end-dash.js"></script>
 ```
 
-## Templating from models
-
-Define your templates:
+Define your templates.
 
 ```html
 <script type="text/enddash" name="character">
@@ -45,15 +41,21 @@ Define your templates:
   </div>
 </script>
 ```
+
 WARNING: A template can only have one root element. In the above case, it is the div with class 'user'.
 
-Bind templates to models in your application code:
+Load your templates into EndDash.
 
 ```javascript
 $.ready(function() {
   // Load all the templates on the page.
   EndDash.bootstrap();
+)};
+```
 
+Bind your templates to models in your application code.
+
+```javascript
   var tony = new Backbone.Model({
     firstName: 'Tony',
     lastName: 'Stark',
@@ -66,7 +68,7 @@ $.ready(function() {
 });
 ```
 
-If your model changes, the DOM updates!
+If your models changes, the DOM will update to reflect the changes.
 
 ## Building and testing
 


### PR DESCRIPTION
@bglusman @yaymukund Making the getting started section easier to read. The name 'Templating with models' was confusing. I deleted this and subsumed the code into 'getting started'.

This makes reading and understanding the steps from 'cloning EndDash' to 'HTML with model attributes interpolated on the page' much easier to see and understand.
