### PR TITLE
Doc makeover

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,8 @@ EndDash is a bindings-aware client-side templating language built on top of vali
 At this point EndDash relies on Backbone or Backbone style objects for full functionality.
 Please [see the dependency section](#dependencies) for further details.
 
+([Full Documentation](#documentation) is below)
+
 Getting Started
 ===============
 

--- a/README.md
+++ b/README.md
@@ -3,8 +3,8 @@ EndDash
 
 EndDash is a bindings-aware client-side templating language built on top of valid HTML.
 
-At this point EndDash relies on Backbone or Backbone style objects for full functionality.
-Please [see the dependency section](#dependencies) for further details.
+In its current release, EndDash relies on Backbone style objects.
+See [the dependency section](#dependencies) for further details.
 
 ([Documentation](#documentation) is below)
 

--- a/README.md
+++ b/README.md
@@ -8,14 +8,23 @@ Please [see the dependency section](#dependencies) for further details.
 
 [Getting started](#getting-started)
 
-[Building and testing](#building-and-testing)
-
-[Play with examples](#play-with-examples)
-
 [Documentation](#documentation)
 
 
-## Getting started
+Getting started
+===============
+
+Install EndDash and install grunt helper
+
+```bash
+npm install
+
+# We use grunt for running tasks.
+npm install -g grunt-cli
+
+# Build end-dash in build/ directory
+grunt build # also aliased as `grunt`
+```
 
 Include the library and dependencies.
 
@@ -23,7 +32,7 @@ Include the library and dependencies.
 <script src="//ajax.googleapis.com/ajax/libs/jquery/1.10.2/jquery.min.js"></script>
 <script src="http://underscorejs.org/underscore.js"></script>
 <script src="http://backbonejs.org/backbone.js"></script>
-<script src="/scripts/end-dash.js"></script>
+<script src="/end-dash/build/end-dash.js"></script>
 ```
 
 Define your templates.
@@ -69,25 +78,7 @@ Bind your templates to models in your application code.
 
 If your models changes, the DOM will update to reflect the changes.
 
-## Building and testing
-
-```bash
-npm install
-
-# We use grunt for running tasks.
-npm install -g grunt-cli
-
-# Build end-dash in build/ directory
-grunt build # also aliased as `grunt`
-
-# Run tests
-grunt test
-
-# Watch for changes and run tests
-grunt watch
-```
-
-## Play with examples
+## Ready Made Examples
 
 If you clone this repo and install grunt as described above
 you can play with some end-dash examples in your browser.

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ EndDash is a bindings-aware client-side templating language built on top of vali
 At this point EndDash relies on Backbone or Backbone style objects for full functionality.
 Please [see the dependency section](#dependencies) for further details.
 
-([Full Documentation](#documentation) is below)
+([Documentation](#documentation) is below)
 
 Getting Started
 ===============

--- a/README.md
+++ b/README.md
@@ -6,12 +6,7 @@ EndDash is a bindings-aware client-side templating language built on top of vali
 At this point EndDash relies on Backbone or Backbone style objects for full functionality.
 Please [see the dependency section](#dependencies) for further details.
 
-[Getting started](#getting-started)
-
-[Documentation](#documentation)
-
-
-Getting started
+Getting Started
 ===============
 
 Install EndDash and install grunt helper
@@ -78,7 +73,8 @@ Bind your templates to models in your application code.
 
 If your models changes, the DOM will update to reflect the changes.
 
-## Ready Made Examples
+Ready Made Examples
+===================
 
 If you clone this repo and install grunt as described above
 you can play with some end-dash examples in your browser.


### PR DESCRIPTION
@yaymukund @bglusman 

I think this is a pretty hot change. I got ride of the top menu (getting started, play with examples etc... It felt clanky / a little confusing to have that and the documentation links.)

I also change the backbone warning to be shorter.

People hitting the repo should see the intro then immediately see how to get started & play with examples.

Then they can hit the docs :)
