### PR TITLE
Fix trigger dom issue

### DIFF
--- a/lib/reactions/variable.js
+++ b/lib/reactions/variable.js
@@ -3,7 +3,7 @@ var Reaction = require("../reaction"),
 
 var VariableReaction = Reaction.extend({
 
-  setFrom: function(key, initialSet) {
+  setFrom: function(key) {
     var newVal = this.get(key),
         oldVal,
         shouldTriggerChange = false,
@@ -38,8 +38,10 @@ var VariableReaction = Reaction.extend({
           el.val(newVal);
         }
       }
-      if (shouldTriggerChange && !initialSet) {
+      if (shouldTriggerChange) {
         this.triggerDOMChange();
+      } else if (this.firstSetHappening) {
+        this.firstSetHappening = false
       }
     } else {
       oldVal = el.html();
@@ -55,7 +57,8 @@ var VariableReaction = Reaction.extend({
 
   init: function(next) {
     next();
-    this.setFrom(this.variableName, true);
+    this.firstSetHappening = true
+    this.setFrom(this.variableName);
   },
 
   observe: function() {
@@ -67,6 +70,11 @@ var VariableReaction = Reaction.extend({
     if((this.isInput || this.isContentEditable) && !this.isReadOnly) {
       this.clearUiEvent(events);
       this.uiEvent(events, function() {
+        if (that.firstSetHappening) {
+          that.firstSetHappening = false
+          return;
+        }
+
         if(that.isContentEditable) {
           return model.set(key, that.el.html(), { validate: true });
         }

--- a/lib/reactions/variable.js
+++ b/lib/reactions/variable.js
@@ -41,7 +41,7 @@ var VariableReaction = Reaction.extend({
       if (shouldTriggerChange) {
         this.triggerDOMChange();
       } else if (this.firstSetHappening) {
-        this.firstSetHappening = false
+        this.firstSetHappening = false;
       }
     } else {
       oldVal = el.html();
@@ -57,7 +57,7 @@ var VariableReaction = Reaction.extend({
 
   init: function(next) {
     next();
-    this.firstSetHappening = true
+    this.firstSetHappening = true;
     this.setFrom(this.variableName);
   },
 
@@ -71,7 +71,7 @@ var VariableReaction = Reaction.extend({
       this.clearUiEvent(events);
       this.uiEvent(events, function() {
         if (that.firstSetHappening) {
-          that.firstSetHappening = false
+          that.firstSetHappening = false;
           return;
         }
 

--- a/lib/reactions/variable.js
+++ b/lib/reactions/variable.js
@@ -3,7 +3,7 @@ var Reaction = require("../reaction"),
 
 var VariableReaction = Reaction.extend({
 
-  setFrom: function(key) {
+  setFrom: function(key, initialSet) {
     var newVal = this.get(key),
         oldVal,
         shouldTriggerChange = false,
@@ -38,7 +38,7 @@ var VariableReaction = Reaction.extend({
           el.val(newVal);
         }
       }
-      if (shouldTriggerChange) {
+      if (shouldTriggerChange && !initialSet) {
         this.triggerDOMChange();
       }
     } else {
@@ -55,7 +55,7 @@ var VariableReaction = Reaction.extend({
 
   init: function(next) {
     next();
-    this.setFrom(this.variableName);
+    this.setFrom(this.variableName, true);
   },
 
   observe: function() {


### PR DESCRIPTION
@tobowers @pbadger @xcoderzach 

This stops a `model.set` on the first setting of the DOM when binding the dome

a) Its not necessary (we are circularly setting in most cases or else setting `undefined` to `""`). This is because we have the model listen to the DOM and then we call `this.setFrom(variableName)`. This sets the `el` equal to the model value of the variable. This then triggers a DOM `change` (sometimes, if it doesn't that case is handled by setting `firstSetHappening` to false) which sets the property of the `el` back on the model d'oh! If the attribute on the model is `undefined`, we set that on the `el` but calling `el.val()` on a non-value input returns "". Thus we change `undefined` to `""`. 

In both cases, the listener for DOM changes does `model.set(key, that.el.val(), {validate: true})` Yikes! This calls Backbone.Model.validate (thus are validators, like on the registration page, when we don't want to). Solution is, use a boolean to know when its the first set and when its not. There are probably edge cases here, so please look for those.

CHA-:ear:s
