### PR TITLE
Fix cleanup

### DIFF
--- a/lib/reaction.js
+++ b/lib/reaction.js
@@ -95,7 +95,7 @@ Reaction.prototype.change = function(property, callback, context) {
 
 Reaction.prototype.stopObserving = function() {
   this.el.off(".endDash" + this.cid);
-  this.stopListening(this._presenter);
+  this.stopListening();
 };
 
 Reaction.parse = function() {};

--- a/lib/reactions/debugger.js
+++ b/lib/reactions/debugger.js
@@ -19,7 +19,7 @@ var Reaction = require('../reaction');
 
 var DebuggerReaction = Reaction.extend({
   init: function() {
-    this.model.on('sync', this.startDebugger.bind(this));
+    this.listenTo(this.model, 'sync', this.startDebugger);
   },
 
   startDebugger: function() {

--- a/lib/reactions/deprecated_looping.js
+++ b/lib/reactions/deprecated_looping.js
@@ -55,7 +55,7 @@ var DeprecatedLoopingReaction = Reaction.extend({
 
   init: function(next) {
     this.collection = (this.get(this.collectionName) || []);
-    this.collectionPresenter = this.getPresenter(this.collection);
+    this._presenter = this.collectionPresenter = this.getPresenter(this.collection);
 
     this.stack.push(this.collection);
 
@@ -82,6 +82,7 @@ var DeprecatedLoopingReaction = Reaction.extend({
           this.add(model, index);
         }, this);
       }
+
       this.listenTo(this.collectionPresenter, "sort reset", function() {
         this.el.empty();
         this.addAll(this.collectionPresenter);

--- a/lib/reactions/deprecated_looping.js
+++ b/lib/reactions/deprecated_looping.js
@@ -76,22 +76,22 @@ var DeprecatedLoopingReaction = Reaction.extend({
     if(typeof this.collectionPresenter.on === "function") {
 
       if(this.polymorphicKey) {
-        this.collectionPresenter.on("change:" + this.polymorphicKey, function(model) {
+        this.listenTo(this.collectionPresenter, "change:" + this.polymorphicKey, function(model) {
           var index = this.collectionPresenter.indexOf(model);
           this.remove(model, index);
           this.add(model, index);
         }, this);
       }
-      this.collectionPresenter.on("sort reset", function() {
+      this.listenTo(this.collectionPresenter, "sort reset", function() {
         this.el.empty();
         this.addAll(this.collectionPresenter);
       }, this);
 
-      this.collectionPresenter.on("add", function(model) {
+      this.listenTo(this.collectionPresenter, "add", function(model) {
         this.add(model, this.collectionPresenter.indexOf(model));
       }, this);
 
-      this.collectionPresenter.on("remove", function(model, collection, opts) {
+      this.listenTo(this.collectionPresenter, "remove", function(model, collection, opts) {
         this.remove(model, opts.index);
       }, this);
     }

--- a/lib/reactions/looping.js
+++ b/lib/reactions/looping.js
@@ -69,22 +69,22 @@ var LoopingReaction = Reaction.extend({
     if(typeof this.collectionPresenter.on === "function") {
 
       if(this.polymorphicKey) {
-        this.collectionPresenter.on("change:" + this.polymorphicKey, function(model) {
+        this.listenTo(this.collectionPresenter, "change:" + this.polymorphicKey, function(model) {
           var index = this.collectionPresenter.indexOf(model);
           this.remove(model);
           this.add(model, index);
         }, this);
       }
-      this.collectionPresenter.on("sort reset", function() {
+      this.listenTo(this.collectionPresenter, "sort reset", function() {
         this.el.html("");
         this.addAll(this.collectionPresenter);
       }, this);
 
-      this.collectionPresenter.on("add", function(model) {
+      this.listenTo(this.collectionPresenter, "add", function(model) {
         this.add(model, this.collectionPresenter.indexOf(model));
       }, this);
 
-      this.collectionPresenter.on("remove", function(model, collection, opts) {
+      this.listenTo(this.collectionPresenter,"remove", function(model, collection, opts) {
         this.remove(model);
       }, this);
     }

--- a/lib/reactions/looping.js
+++ b/lib/reactions/looping.js
@@ -75,6 +75,7 @@ var LoopingReaction = Reaction.extend({
           this.add(model, index);
         }, this);
       }
+
       this.listenTo(this.collectionPresenter, "sort reset", function() {
         this.el.html("");
         this.addAll(this.collectionPresenter);

--- a/lib/reactions/scope.js
+++ b/lib/reactions/scope.js
@@ -50,7 +50,7 @@ var ScopeReaction = Reaction.extend({
 
       stack.push(val);
       if(change && typeof prev.on === "function") {
-        prev.on("change:" + segment, function() { change(segment); });
+        this.listenTo(prev, "change:" + segment, function() { change(segment); });
       }
     }, this);
     return stack;

--- a/lib/reactions/scope.js
+++ b/lib/reactions/scope.js
@@ -26,12 +26,6 @@ var ScopeReaction = Reaction.extend({
     });
   },
 
-  stopObserving: function(){
-    this.el.off(".endDash" + this.cid);
-    this.stopListening(this._presenter);
-    this.trigger('stopListening');
-  },
-
   execPathOnStack: function(path, stack, change) {
     //if it's an absolute path start from the "root" of the stack
     if(path.charAt(0) === '/') {
@@ -57,9 +51,6 @@ var ScopeReaction = Reaction.extend({
       stack.push(val);
       if(change && typeof prev.on === "function") {
         this.listenTo(prev, "change:" + segment, function() { change(segment); });
-        this.on('stopListening', function(){
-          this.stopListening(prev);
-        });
       }
     }, this);
     return stack;

--- a/lib/reactions/scope.js
+++ b/lib/reactions/scope.js
@@ -26,6 +26,12 @@ var ScopeReaction = Reaction.extend({
     });
   },
 
+  stopObserving: function(){
+    this.el.off(".endDash" + this.cid);
+    this.stopListening(this._presenter);
+    this.trigger('stopListening');
+  },
+
   execPathOnStack: function(path, stack, change) {
     //if it's an absolute path start from the "root" of the stack
     if(path.charAt(0) === '/') {
@@ -51,6 +57,9 @@ var ScopeReaction = Reaction.extend({
       stack.push(val);
       if(change && typeof prev.on === "function") {
         this.listenTo(prev, "change:" + segment, function() { change(segment); });
+        this.on('stopListening', function(){
+          this.stopListening(prev);
+        });
       }
     }, this);
     return stack;

--- a/test/stop_observing.js
+++ b/test/stop_observing.js
@@ -71,7 +71,6 @@ describe("When I clean up a template", function() {
       ]);
 
       var markup = fs.readFileSync(__dirname + "/support/templates/polymorphic.html").toString();
-      this.things.name = 'blo'
       this.template = generateTemplate({things: this.things}, markup);
 
       this.template.cleanup();
@@ -83,6 +82,39 @@ describe("When I clean up a template", function() {
 
       this.things.reset();
       expect($('[data-each]').children().length).to.be(2);
+    });
+
+    it("it does not error when you remove the HTML and then remove a model ", function(){
+      $('.things-').remove()
+      this.things.pop();
+      // This is a very specific bug
+      // JQuery#remove, destroys all listeners/properties from the
+      // elements it removes. Without #cleanup, changing the things
+      // collection after #remove will error because the looping reaction
+      // attempts to delete the DOM element that corrospends to the model
+      // removed. Which is no longer there. Thus undefined.el.remove -> error
+    })
+  });
+
+  describe("with a deprecated template with a collection reaction", function(){
+    beforeEach(function(){
+      this.things = new Collection([
+        new Model({ type: "awesome" }),
+        new Model({ type: "cool" })
+      ]);
+
+      var markup = fs.readFileSync(__dirname + "/deprecated/templates/polymorphic.html").toString();
+      this.template = generateTemplate({things: this.things}, markup);
+
+      this.template.cleanup();
+    });
+
+    it("Does not react", function(){
+      this.things.add(new Model({type: "awesome"}));
+      expect($('.things-').children().length).to.be(2);
+
+      this.things.reset();
+      expect($('.things-').children().length).to.be(2);
     });
 
     it("it does not error when you remove the HTML and then remove a model ", function(){

--- a/test/stop_observing.js
+++ b/test/stop_observing.js
@@ -140,24 +140,23 @@ describe("When I clean up a template", function() {
         this.boot = new Model({name: 'boot', sock: this.sock});
         this.root = new Model({name: 'root', boot: this.boot, model: this.model});
         this.template = generateTemplate(this.root, fs.readFileSync(__dirname + "/support/templates/scopes.html").toString());
-        this.template.cleanup()
+        this.template.cleanup();
       });
 
       it("should be able to access child models of the root scope", function() {
-        this.root.set('model', new Model({name: 'crazy'}))
+        this.root.set('model', new Model({name: 'crazy'}));
         expect($("#modelName").html()).to.be("model");
       });
 
       it("should be able to access a relative scope", function() {
-        this.model.set('thing', new Model({dude: this.dude, name: 'otherThing', item: this.item}))
+        this.model.set('thing', new Model({dude: this.dude, name: 'otherThing', item: this.item}));
         expect($("#thingName").html()).to.be("thing");
       });
 
       it("should be able to modify the scope of a model", function() {
-        this.boot.set('sock', new Model({name: 'Bryant'}))
+        this.boot.set('sock', new Model({name: 'Bryant'}));
         expect($("#sockName").html()).to.be("sock");
       });
     });
   });
-
 });

--- a/test/stop_observing.js
+++ b/test/stop_observing.js
@@ -85,7 +85,7 @@ describe("When I clean up a template", function() {
     });
 
     it("it does not error when you remove the HTML and then remove a model ", function(){
-      $('.things-').remove()
+      $('.things-').remove();
       this.things.pop();
       // This is a very specific bug
       // JQuery#remove, destroys all listeners/properties from the
@@ -93,7 +93,7 @@ describe("When I clean up a template", function() {
       // collection after #remove will error because the looping reaction
       // attempts to delete the DOM element that corrospends to the model
       // removed. Which is no longer there. Thus undefined.el.remove -> error
-    })
+    });
   });
 
   describe("with a deprecated template with a collection reaction", function(){
@@ -118,7 +118,7 @@ describe("When I clean up a template", function() {
     });
 
     it("it does not error when you remove the HTML and then remove a model ", function(){
-      $('.things-').remove()
+      $('.things-').remove();
       this.things.pop();
       // This is a very specific bug
       // JQuery#remove, destroys all listeners/properties from the
@@ -126,7 +126,43 @@ describe("When I clean up a template", function() {
       // collection after #remove will error because the looping reaction
       // attempts to delete the DOM element that corrospends to the model
       // removed. Which is no longer there. Thus undefined.el.remove -> error
-    })
+    });
+  });
+
+  describe("A template with lots of scoping", function() {
+    describe("which has data-scope attributes", function() {
+      before(function() {
+        this.dude = new Model({name: 'dude'});
+        this.item = new Model({name: 'item'});
+        this.thing = new Model({name: 'thing', dude: this.dude, item: this.item});
+        this.model = new Model({name: 'model', thing: this.thing, item: this.item});
+        this.sock = new Model({name: 'sock'});
+        this.boot = new Model({name: 'boot', sock: this.sock});
+        this.root = new Model({name: 'root', boot: this.boot, model: this.model});
+        this.template = generateTemplate(this.root, fs.readFileSync(__dirname + "/support/templates/scopes.html").toString());
+        // this.template.cleanup()
+      });
+
+      it("should be able to access the root scope", function() {
+        expect($("#rootName").html()).to.be("root");
+      });
+
+      it("should be able to access child models of the root scope", function() {
+        expect($("#modelName").html()).to.be("model");
+      });
+
+      it("should be able to access a relative scope", function() {
+        expect($("#thingName").html()).to.be("thing");
+      });
+
+      it("should be able to access a model after relative scope", function() {
+        expect($("#itemName").html()).to.be("item");
+      });
+
+      it("should be able to modify the scope of a model", function() {
+        expect($("#sockName").html()).to.be("sock");
+      });
+    });
   });
 
 });

--- a/test/stop_observing.js
+++ b/test/stop_observing.js
@@ -140,26 +140,21 @@ describe("When I clean up a template", function() {
         this.boot = new Model({name: 'boot', sock: this.sock});
         this.root = new Model({name: 'root', boot: this.boot, model: this.model});
         this.template = generateTemplate(this.root, fs.readFileSync(__dirname + "/support/templates/scopes.html").toString());
-        // this.template.cleanup()
-      });
-
-      it("should be able to access the root scope", function() {
-        expect($("#rootName").html()).to.be("root");
+        this.template.cleanup()
       });
 
       it("should be able to access child models of the root scope", function() {
+        this.root.set('model', new Model({name: 'crazy'}))
         expect($("#modelName").html()).to.be("model");
       });
 
       it("should be able to access a relative scope", function() {
+        this.model.set('thing', new Model({dude: this.dude, name: 'otherThing', item: this.item}))
         expect($("#thingName").html()).to.be("thing");
       });
 
-      it("should be able to access a model after relative scope", function() {
-        expect($("#itemName").html()).to.be("item");
-      });
-
       it("should be able to modify the scope of a model", function() {
+        this.boot.set('sock', new Model({name: 'Bryant'}))
         expect($("#sockName").html()).to.be("sock");
       });
     });

--- a/test/support/helper.js
+++ b/test/support/helper.js
@@ -11,7 +11,3 @@ before(function(done) {
     done();
   });
 });
-
-afterEach(function(){
-  this.template && this.template.cleanup()
-})

--- a/test/support/helper.js
+++ b/test/support/helper.js
@@ -11,3 +11,7 @@ before(function(done) {
     done();
   });
 });
+
+afterEach(function(){
+  this.template && this.template.cleanup()
+})


### PR DESCRIPTION
This PR changes all external listeners in EndDash to use `listenTo` so that cleanup is as easy as `this.el.off(); this.stopListening(this._presenter);`. (exception is scope.js which utilizes a more complex schema). This fixes the bug that right now `Template.js#cleanup` does not actually cleanup all the listeners :smile: 

@yaymukund @tobowers @xcoderzach 
