### PR TITLE
Fix scope sucking

### DIFF
--- a/lib/reactions/scope.js
+++ b/lib/reactions/scope.js
@@ -15,15 +15,22 @@ var ScopeReaction = Reaction.extend({
   observe: function(next) {
     var that = this;
 
+
+    // Since we are scoping, a change is a higher level model changing
+    // Try this with scoping down
+
     var newStack = this.execPathOnStack(this.el.attr("data-scope"), this.origStack, function(segment) {
+      var modelIndex;
       var changed = _(that.stack).every(function(model, index) {
+        modelIndex = index;
         return newStack[index] === model;
       });
+
       if(changed) {
-        that.stack = newStack;
+        newStack = that.stack = that.execPathOnStack(segment, that.stack.slice(0, modelIndex), function(){}, false);
         next(true);
       }
-    });
+    }, true);
   },
 
   execPathOnStack: function(path, stack, change) {

--- a/lib/reactions/scope.js
+++ b/lib/reactions/scope.js
@@ -8,32 +8,30 @@ var Reaction = require("../reaction"),
 var ScopeReaction = Reaction.extend({
   init: function(next) {
     this.origStack = this.stack.slice(0);
-    this.stack = this.execPathOnStack(this.el.attr("data-scope"), this.stack);
+    this.path = this.el.attr("data-scope")
+    this.stack = this.execPathOnStack(this.path, this.stack);
     next();
   },
 
   observe: function(next) {
-    var that = this;
-
 
     // Since we are scoping, a change is a higher level model changing
     // Try this with scoping down
+    var that = this;
 
-    var newStack = this.execPathOnStack(this.el.attr("data-scope"), this.origStack, function(segment) {
-      var modelIndex;
-      var changed = _(that.stack).every(function(model, index) {
-        modelIndex = index;
-        return newStack[index] === model;
-      });
-
-      if(changed) {
-        newStack = that.stack = that.execPathOnStack(segment, that.stack.slice(0, modelIndex), function(){}, false);
+    var onChange = function(updateChildren) {
+      that.stopListening();
+      that.stack = that.origStack.slice(0);
+      that.execPathOnStack(that.path, that.stack, onChange);
+      if (updateChildren)
         next(true);
-      }
-    }, true);
+    }
+
+    onChange(false)
   },
 
   execPathOnStack: function(path, stack, change) {
+
     //if it's an absolute path start from the "root" of the stack
     if(path.charAt(0) === '/') {
       stack.splice(1, stack.length - 1);
@@ -57,9 +55,10 @@ var ScopeReaction = Reaction.extend({
 
       stack.push(val);
       if(change && typeof prev.on === "function") {
-        prev.on("change:" + segment, function() { change(segment); });
+        prev.on("change:" + segment, function() { change(true); });
       }
     }, this);
+
     return stack;
   }
 

--- a/test/scope_modifier.js
+++ b/test/scope_modifier.js
@@ -2,33 +2,20 @@ require('./support/helper');
 
 var expect = require("expect.js"),
     fs = require("fs"),
-    generateTemplate = require("./support/generate_template");
+    generateTemplate = require("./support/generate_template"),
+    Model = require('../lib/end-dash').Backbone.Model;
 
 describe("An template", function() {
   describe("which has data-scope attributes", function() {
     before(function() {
-      var root = {
-        name: "root",
-        boot: {
-          name: "boot",
-          sock: {
-            name: "sock"
-          }
-        },
-        model: {
-          name: "model",
-          thing: {
-            name: "thing",
-            dude: {
-              name: "dude"
-            },
-            item: {
-              name: "item"
-            }
-          }
-        }
-      };
-      var template = generateTemplate(root, fs.readFileSync(__dirname + "/support/templates/scopes.html").toString());
+      this.dude = new Model({name: 'dude'});
+      this.item = new Model({name: 'item'});
+      this.thing = new Model({name: 'thing', dude: this.dude, item: this.item});
+      this.model = new Model({name: 'model', thing: this.thing, item: this.item});
+      this.sock = new Model({name: 'sock'});
+      this.boot = new Model({name: 'boot', sock: this.sock});
+      this.root = new Model({name: 'root', boot: this.boot, model: this.model});
+      this.template = generateTemplate(this.root, fs.readFileSync(__dirname + "/support/templates/scopes.html").toString());
     });
 
     it("should be able to access the root scope", function() {
@@ -43,12 +30,27 @@ describe("An template", function() {
       expect($("#thingName").html()).to.be("thing");
     });
 
+    it("should update a relative scope after it changes", function(){
+      expect($("#thingName").html()).to.be("thing");
+    })
+
     it("should be able to access a model after relative scope", function() {
-      expect($("#itemName").html()).to.be("item");
+      this.thing.set('item', new Model({name: 'Lebron'}));
+      this.model.set('item', new Model({name: 'Lebron'}));
+      expect($("#itemName").html()).to.be("Lebron");
+
+      this.thing.set('item', new Model({name: 'Bill'}));
+      this.model.set('item', new Model({name: 'Bill'}));
+      expect($("#itemName").html()).to.be("Bill");
     });
 
     it("should be able to modify the scope of a model", function() {
       expect($("#sockName").html()).to.be("sock");
+    });
+
+    it("should update properly when changing the parent model the scope of a model", function() {
+      this.boot.set('sock', new Model({name: 'Bryant'}))
+      expect($("#sockName").html()).to.be("Bryant");
     });
   });
 });


### PR DESCRIPTION
@xcoderzach @tobowers @yaymukund 

So.... scoping update on model changes was broken....

``` javascript
//Scope modifier spec
    it("should be able to access a model after relative scope", function() {
      this.thing.set('item', new Model({name: 'Lebron'}));
      this.model.set('item', new Model({name: 'Lebron'}));
      expect($("#itemName").html()).to.be("Lebron");
    });
```

This would fail... ie., it would not actually update the DOM

Need to work on this more but wanted to update you to this being an issue (even in current brief end-dash) and to let you have a chance to glance at this in case you had feedback. I will more working on this more at some point :smile: 
