### PR TITLE
Return a blank model, if what is passed in is undefined

### DIFF
--- a/lib/util.js
+++ b/lib/util.js
@@ -81,7 +81,6 @@ exports.toBackboneModel = function(model) {
   }
 
   if (model && typeof model !== 'object') {
-    debugger
     throw new Error('Tried to bind template to a '+typeof model+', but '+
                     'templates can only be bound to objects.');
   }

--- a/lib/util.js
+++ b/lib/util.js
@@ -80,7 +80,7 @@ exports.toBackboneModel = function(model) {
     return model;
   }
 
-  if (model && typeof model !== 'object') {
+  if (typeof model !== 'object' && typeof model !== 'undefined') {
     throw new Error('Tried to bind template to a '+typeof model+', but '+
                     'templates can only be bound to objects.');
   }

--- a/lib/util.js
+++ b/lib/util.js
@@ -80,7 +80,8 @@ exports.toBackboneModel = function(model) {
     return model;
   }
 
-  if (typeof model !== 'object') {
+  if (model && typeof model !== 'object') {
+    debugger
     throw new Error('Tried to bind template to a '+typeof model+', but '+
                     'templates can only be bound to objects.');
   }


### PR DESCRIPTION
@tobowers @yaymukund @xcoderzach 

``` javascript
<div class='selectedQuestion-'>
  <span class='isName-'> </span>
</div>
```

If there is no currently selected question, EndDash errors with 'cannot bind undefined to template'
Even wrapping above in `<div class='isSelectedQuestion-'>` errored

This PR fixes this with the logic, 'if the model scoped into is undefined, simply bind it to a blank Backbone model'. 

This:

a) Displays the correct boolean logic 
   It will not show anything inside of `<div class='isSelectedQuestion-'>`

b) Updates properly if `selectedQuestion` is set on the model in scope

c) Does not error

Negative is:

a) It might be harder to debug

Its worth noting, this is how EndDash behaves in release 0.3.3a<= 

There may be a better long term solution (don't bind reactions inside false conditionals) however this is a hard fix and requires more thinking. This is a good short-term solution that behaves correctly.
